### PR TITLE
Improved product's toString to include strings

### DIFF
--- a/src/build/genprod.scala
+++ b/src/build/genprod.scala
@@ -302,7 +302,7 @@ class Tuple(val i: Int) extends Group("Tuple") with Arity {
 
   // prettifies it a little if it's overlong
   def mkToString() = {
-  def str(xs: List[String]) = xs.mkString(""" + "," + """)
+  def str(xs: List[String]) = xs.map(x => "tup_to_s(" + x + ")").mkString(""" + "," + """)
     if (i <= MAX_ARITY / 2) str(mdefs)
     else {
       val s1 = str(mdefs take (i / 2))
@@ -310,6 +310,12 @@ class Tuple(val i: Int) extends Group("Tuple") with Arity {
       s1 + " +\n    \",\" + " + s2
     }
   }
+  def tupToSDef(): String = """
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
+  """
 
   def apply() = {
 <file name={fileName}>{header}
@@ -325,6 +331,7 @@ case class {className}{covariantArgs}({fields})
 {{
   override def toString() = "(" + {mkToString} + ")"
   {moreMethods}
+  {tupToSDef}
 }}
 </file>}
 } // object Tuple

--- a/src/library/scala/Product.scala
+++ b/src/library/scala/Product.scala
@@ -42,6 +42,12 @@ trait Product extends Any with Equals {
     def next() = { val result = productElement(c); c += 1; result }
   }
 
+  def productToString: String =
+    productIterator.map(_ match {
+      case x: String => "\"" + x + "\""
+      case x => x
+    }).mkString("(", ", ", ")")
+
   /** A string used in the `toString` methods of derived classes.
    *  Implementations may override this method to prepend a string prefix
    *  to the result of `toString` methods.

--- a/src/library/scala/Tuple1.scala
+++ b/src/library/scala/Tuple1.scala
@@ -19,6 +19,12 @@ package scala
 case class Tuple1[@specialized(Int, Long, Double) +T1](_1: T1)
   extends Product1[T1]
 {
-  override def toString() = "(" + _1 + ")"
+  override def toString() = "(" + tup_to_s(_1) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple10.scala
+++ b/src/library/scala/Tuple10.scala
@@ -28,6 +28,12 @@ package scala
 case class Tuple10[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10)
   extends Product10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + "," + _7 + "," + _8 + "," + _9 + "," + _10 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + "," + tup_to_s(_7) + "," + tup_to_s(_8) + "," + tup_to_s(_9) + "," + tup_to_s(_10) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple11.scala
+++ b/src/library/scala/Tuple11.scala
@@ -29,6 +29,12 @@ package scala
 case class Tuple11[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11)
   extends Product11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + "," + _7 + "," + _8 + "," + _9 + "," + _10 + "," + _11 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + "," + tup_to_s(_7) + "," + tup_to_s(_8) + "," + tup_to_s(_9) + "," + tup_to_s(_10) + "," + tup_to_s(_11) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple12.scala
+++ b/src/library/scala/Tuple12.scala
@@ -30,7 +30,13 @@ package scala
 case class Tuple12[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12)
   extends Product12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 +
-    "," + _7 + "," + _8 + "," + _9 + "," + _10 + "," + _11 + "," + _12 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) +
+    "," + tup_to_s(_7) + "," + tup_to_s(_8) + "," + tup_to_s(_9) + "," + tup_to_s(_10) + "," + tup_to_s(_11) + "," + tup_to_s(_12) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple13.scala
+++ b/src/library/scala/Tuple13.scala
@@ -31,7 +31,13 @@ package scala
 case class Tuple13[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13)
   extends Product13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 +
-    "," + _7 + "," + _8 + "," + _9 + "," + _10 + "," + _11 + "," + _12 + "," + _13 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) +
+    "," + tup_to_s(_7) + "," + tup_to_s(_8) + "," + tup_to_s(_9) + "," + tup_to_s(_10) + "," + tup_to_s(_11) + "," + tup_to_s(_12) + "," + tup_to_s(_13) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple14.scala
+++ b/src/library/scala/Tuple14.scala
@@ -32,7 +32,13 @@ package scala
 case class Tuple14[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14)
   extends Product14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + "," + _7 +
-    "," + _8 + "," + _9 + "," + _10 + "," + _11 + "," + _12 + "," + _13 + "," + _14 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + "," + tup_to_s(_7) +
+    "," + tup_to_s(_8) + "," + tup_to_s(_9) + "," + tup_to_s(_10) + "," + tup_to_s(_11) + "," + tup_to_s(_12) + "," + tup_to_s(_13) + "," + tup_to_s(_14) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple15.scala
+++ b/src/library/scala/Tuple15.scala
@@ -33,7 +33,13 @@ package scala
 case class Tuple15[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15)
   extends Product15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + "," + _7 +
-    "," + _8 + "," + _9 + "," + _10 + "," + _11 + "," + _12 + "," + _13 + "," + _14 + "," + _15 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + "," + tup_to_s(_7) +
+    "," + tup_to_s(_8) + "," + tup_to_s(_9) + "," + tup_to_s(_10) + "," + tup_to_s(_11) + "," + tup_to_s(_12) + "," + tup_to_s(_13) + "," + tup_to_s(_14) + "," + tup_to_s(_15) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple16.scala
+++ b/src/library/scala/Tuple16.scala
@@ -34,7 +34,13 @@ package scala
 case class Tuple16[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16)
   extends Product16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + "," + _7 + "," + _8 +
-    "," + _9 + "," + _10 + "," + _11 + "," + _12 + "," + _13 + "," + _14 + "," + _15 + "," + _16 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + "," + tup_to_s(_7) + "," + tup_to_s(_8) +
+    "," + tup_to_s(_9) + "," + tup_to_s(_10) + "," + tup_to_s(_11) + "," + tup_to_s(_12) + "," + tup_to_s(_13) + "," + tup_to_s(_14) + "," + tup_to_s(_15) + "," + tup_to_s(_16) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple17.scala
+++ b/src/library/scala/Tuple17.scala
@@ -35,7 +35,13 @@ package scala
 case class Tuple17[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16, _17: T17)
   extends Product17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + "," + _7 + "," + _8 +
-    "," + _9 + "," + _10 + "," + _11 + "," + _12 + "," + _13 + "," + _14 + "," + _15 + "," + _16 + "," + _17 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + "," + tup_to_s(_7) + "," + tup_to_s(_8) +
+    "," + tup_to_s(_9) + "," + tup_to_s(_10) + "," + tup_to_s(_11) + "," + tup_to_s(_12) + "," + tup_to_s(_13) + "," + tup_to_s(_14) + "," + tup_to_s(_15) + "," + tup_to_s(_16) + "," + tup_to_s(_17) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple18.scala
+++ b/src/library/scala/Tuple18.scala
@@ -36,7 +36,13 @@ package scala
 case class Tuple18[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16, _17: T17, _18: T18)
   extends Product18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + "," + _7 + "," + _8 + "," + _9 +
-    "," + _10 + "," + _11 + "," + _12 + "," + _13 + "," + _14 + "," + _15 + "," + _16 + "," + _17 + "," + _18 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + "," + tup_to_s(_7) + "," + tup_to_s(_8) + "," + tup_to_s(_9) +
+    "," + tup_to_s(_10) + "," + tup_to_s(_11) + "," + tup_to_s(_12) + "," + tup_to_s(_13) + "," + tup_to_s(_14) + "," + tup_to_s(_15) + "," + tup_to_s(_16) + "," + tup_to_s(_17) + "," + tup_to_s(_18) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple19.scala
+++ b/src/library/scala/Tuple19.scala
@@ -37,7 +37,13 @@ package scala
 case class Tuple19[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16, _17: T17, _18: T18, _19: T19)
   extends Product19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + "," + _7 + "," + _8 + "," + _9 +
-    "," + _10 + "," + _11 + "," + _12 + "," + _13 + "," + _14 + "," + _15 + "," + _16 + "," + _17 + "," + _18 + "," + _19 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + "," + tup_to_s(_7) + "," + tup_to_s(_8) + "," + tup_to_s(_9) +
+    "," + tup_to_s(_10) + "," + tup_to_s(_11) + "," + tup_to_s(_12) + "," + tup_to_s(_13) + "," + tup_to_s(_14) + "," + tup_to_s(_15) + "," + tup_to_s(_16) + "," + tup_to_s(_17) + "," + tup_to_s(_18) + "," + tup_to_s(_19) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple2.scala
+++ b/src/library/scala/Tuple2.scala
@@ -20,7 +20,7 @@ package scala
 case class Tuple2[@specialized(Int, Long, Double, Char, Boolean/*, AnyRef*/) +T1, @specialized(Int, Long, Double, Char, Boolean/*, AnyRef*/) +T2](_1: T1, _2: T2)
   extends Product2[T1, T2]
 {
-  override def toString() = "(" + _1 + "," + _2 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + ")"
   
   /** Swaps the elements of this `Tuple`.
    * @return a new Tuple where the first element is the second element of this Tuple and the
@@ -28,4 +28,10 @@ case class Tuple2[@specialized(Int, Long, Double, Char, Boolean/*, AnyRef*/) +T1
    */
   def swap: Tuple2[T2,T1] = Tuple2(_2, _1)
 
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
+  
 }

--- a/src/library/scala/Tuple20.scala
+++ b/src/library/scala/Tuple20.scala
@@ -38,7 +38,13 @@ package scala
 case class Tuple20[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16, _17: T17, _18: T18, _19: T19, _20: T20)
   extends Product20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + "," + _7 + "," + _8 + "," + _9 + "," + _10 +
-    "," + _11 + "," + _12 + "," + _13 + "," + _14 + "," + _15 + "," + _16 + "," + _17 + "," + _18 + "," + _19 + "," + _20 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + "," + tup_to_s(_7) + "," + tup_to_s(_8) + "," + tup_to_s(_9) + "," + tup_to_s(_10) +
+    "," + tup_to_s(_11) + "," + tup_to_s(_12) + "," + tup_to_s(_13) + "," + tup_to_s(_14) + "," + tup_to_s(_15) + "," + tup_to_s(_16) + "," + tup_to_s(_17) + "," + tup_to_s(_18) + "," + tup_to_s(_19) + "," + tup_to_s(_20) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple21.scala
+++ b/src/library/scala/Tuple21.scala
@@ -39,7 +39,13 @@ package scala
 case class Tuple21[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20, +T21](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16, _17: T17, _18: T18, _19: T19, _20: T20, _21: T21)
   extends Product21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + "," + _7 + "," + _8 + "," + _9 + "," + _10 +
-    "," + _11 + "," + _12 + "," + _13 + "," + _14 + "," + _15 + "," + _16 + "," + _17 + "," + _18 + "," + _19 + "," + _20 + "," + _21 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + "," + tup_to_s(_7) + "," + tup_to_s(_8) + "," + tup_to_s(_9) + "," + tup_to_s(_10) +
+    "," + tup_to_s(_11) + "," + tup_to_s(_12) + "," + tup_to_s(_13) + "," + tup_to_s(_14) + "," + tup_to_s(_15) + "," + tup_to_s(_16) + "," + tup_to_s(_17) + "," + tup_to_s(_18) + "," + tup_to_s(_19) + "," + tup_to_s(_20) + "," + tup_to_s(_21) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple22.scala
+++ b/src/library/scala/Tuple22.scala
@@ -40,7 +40,13 @@ package scala
 case class Tuple22[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20, +T21, +T22](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16, _17: T17, _18: T18, _19: T19, _20: T20, _21: T21, _22: T22)
   extends Product22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + "," + _7 + "," + _8 + "," + _9 + "," + _10 + "," + _11 +
-    "," + _12 + "," + _13 + "," + _14 + "," + _15 + "," + _16 + "," + _17 + "," + _18 + "," + _19 + "," + _20 + "," + _21 + "," + _22 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + "," + tup_to_s(_7) + "," + tup_to_s(_8) + "," + tup_to_s(_9) + "," + tup_to_s(_10) + "," + tup_to_s(_11) +
+    "," + tup_to_s(_12) + "," + tup_to_s(_13) + "," + tup_to_s(_14) + "," + tup_to_s(_15) + "," + tup_to_s(_16) + "," + tup_to_s(_17) + "," + tup_to_s(_18) + "," + tup_to_s(_19) + "," + tup_to_s(_20) + "," + tup_to_s(_21) + "," + tup_to_s(_22) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple3.scala
+++ b/src/library/scala/Tuple3.scala
@@ -21,6 +21,12 @@ package scala
 case class Tuple3[+T1, +T2, +T3](_1: T1, _2: T2, _3: T3)
   extends Product3[T1, T2, T3]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple4.scala
+++ b/src/library/scala/Tuple4.scala
@@ -22,6 +22,12 @@ package scala
 case class Tuple4[+T1, +T2, +T3, +T4](_1: T1, _2: T2, _3: T3, _4: T4)
   extends Product4[T1, T2, T3, T4]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple5.scala
+++ b/src/library/scala/Tuple5.scala
@@ -23,6 +23,12 @@ package scala
 case class Tuple5[+T1, +T2, +T3, +T4, +T5](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5)
   extends Product5[T1, T2, T3, T4, T5]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple6.scala
+++ b/src/library/scala/Tuple6.scala
@@ -24,6 +24,12 @@ package scala
 case class Tuple6[+T1, +T2, +T3, +T4, +T5, +T6](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6)
   extends Product6[T1, T2, T3, T4, T5, T6]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple7.scala
+++ b/src/library/scala/Tuple7.scala
@@ -25,6 +25,12 @@ package scala
 case class Tuple7[+T1, +T2, +T3, +T4, +T5, +T6, +T7](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7)
   extends Product7[T1, T2, T3, T4, T5, T6, T7]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + "," + _7 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + "," + tup_to_s(_7) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple8.scala
+++ b/src/library/scala/Tuple8.scala
@@ -26,6 +26,12 @@ package scala
 case class Tuple8[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8)
   extends Product8[T1, T2, T3, T4, T5, T6, T7, T8]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + "," + _7 + "," + _8 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + "," + tup_to_s(_7) + "," + tup_to_s(_8) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/Tuple9.scala
+++ b/src/library/scala/Tuple9.scala
@@ -27,6 +27,12 @@ package scala
 case class Tuple9[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9)
   extends Product9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
 {
-  override def toString() = "(" + _1 + "," + _2 + "," + _3 + "," + _4 + "," + _5 + "," + _6 + "," + _7 + "," + _8 + "," + _9 + ")"
+  override def toString() = "(" + tup_to_s(_1) + "," + tup_to_s(_2) + "," + tup_to_s(_3) + "," + tup_to_s(_4) + "," + tup_to_s(_5) + "," + tup_to_s(_6) + "," + tup_to_s(_7) + "," + tup_to_s(_8) + "," + tup_to_s(_9) + ")"
+  
+  
+    private def tup_to_s(x: Any): String = x match {
+      case (xx: String) => "\"" + xx + "\""
+      case xx => xx.toString()
+    }
   
 }

--- a/src/library/scala/runtime/ScalaRunTime.scala
+++ b/src/library/scala/runtime/ScalaRunTime.scala
@@ -163,7 +163,7 @@ object ScalaRunTime {
     if (x == null) throw new UninitializedError else x
 
   def _toString(x: Product): String =
-    x.productIterator.mkString(x.productPrefix + "(", ",", ")")
+    x.productToString
 
   def _hashCode(x: Product): Int = scala.util.hashing.MurmurHash3.productHash(x)
 

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -1106,7 +1106,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
 
   /** Hook for extensions */
   def xprintTree(treePrinter: TreePrinter, tree: Tree) =
-    treePrinter.print(tree.productPrefix+tree.productIterator.mkString("(", ", ", ")"))
+    treePrinter.print(tree.productPrefix+tree.productToString)
 
   def newCodePrinter(writer: PrintWriter, tree: Tree, printRootPkg: Boolean): TreePrinter =
     new CodePrinter(writer, printRootPkg)

--- a/src/reflect/scala/reflect/internal/TypeDebugging.scala
+++ b/src/reflect/scala/reflect/internal/TypeDebugging.scala
@@ -78,7 +78,7 @@ trait TypeDebugging {
       // otherwise case classes are caught looking like products
       case _: Tree | _: Type     => "" + x
       case x: TraversableOnce[_] => x mkString ", "
-      case x: Product            => x.productIterator mkString ("(", ", ", ")")
+      case x: Product            => x.productToString
       case _                     => "" + x
     }
     def ptBlock(label: String, pairs: (String, Any)*): String = {


### PR DESCRIPTION
Test frameworks and debuggers use `toString` to show string-based information to users. It helps users a lot if strings are shown with quotes.

```
scala> case class Person(name: String, age: Int)
defined class Person

scala> Person("", 0)
res0: Person = ("", 0)
```
