### PR TITLE
Add an @implicitAmbiguous annotation

### DIFF
--- a/build-ant-macros.xml
+++ b/build-ant-macros.xml
@@ -733,6 +733,7 @@
 
     <sequential>
       <deploy-one name="scala-library"     local="@{local}" signed="@{signed}"/>
+      <deploy-one name="scala-typelevel"   local="@{local}" signed="@{signed}"/>
       <deploy-one name="scala-reflect"     local="@{local}" signed="@{signed}"/>
       <deploy-one name="scala-compiler"    local="@{local}" signed="@{signed}"/>
 

--- a/build.xml
+++ b/build.xml
@@ -349,6 +349,7 @@ TODO:
           <path refid="external-modules.deps.classpath"/>
           <rsel:not><rsel:or>
             <rsel:name name="scala-library*.jar"/>
+            <rsel:name name="scala-typelevel*.jar"/>
             <rsel:name name="scala-reflect*.jar"/>
             <rsel:name name="scala-compiler*.jar"/>
           </rsel:or></rsel:not>
@@ -650,7 +651,7 @@ TODO:
     <property name="partest-javaagent.description" value="Scala Compiler Testing Tool (compiler-specific java agent)"/>
 
     <!-- projects without project-specific options: asm, forkjoin, manual, bin, repl -->
-    <for list="actors,compiler,interactive,scaladoc,library,parser-combinators,partest,partest-extras,partest-javaagent,reflect,scalap,swing,xml,continuations-plugin,continuations-library" param="project">
+    <for list="actors,compiler,interactive,scaladoc,library,typelevel,parser-combinators,partest,partest-extras,partest-javaagent,reflect,scalap,swing,xml,continuations-plugin,continuations-library" param="project">
       <sequential>
         <!-- description is mandatory -->
         <init-project-prop project="@{project}" name="package"     default=""/> <!-- used by mvn-package, copy-bundle, make-bundle -->
@@ -732,6 +733,11 @@ TODO:
       <path refid="aux.libs"/>
     </path>
 
+    <path id="quick.typelevel.build.path">
+      <path refid="quick.library.build.path"/>
+      <pathelement location="${build-quick.dir}/classes/typelevel"/>
+    </path>
+
     <path id="quick.actors.build.path">
       <path refid="quick.library.build.path"/>
       <pathelement location="${build-quick.dir}/classes/actors"/>
@@ -786,6 +792,7 @@ TODO:
 
     <path id="quick.bin.tool.path">
       <path refid="quick.repl.build.path"/>
+      <path refid="quick.typelevel.build.path"/>
       <path refid="quick.actors.build.path"/>
       <pathelement location="${build-quick.dir}/classes/scalap"/>
       <pathelement location="${build-quick.dir}/classes/scaladoc"/>
@@ -795,6 +802,7 @@ TODO:
     <!-- PACK -->
     <path id="pack.compiler.path">
       <pathelement location="${library.jar}"/>
+      <pathelement location="${typelevel.jar}"/>
       <pathelement location="${reflect.jar}"/>
       <pathelement location="${compiler.jar}"/>
       <pathelement location="${ant.jar}"/>
@@ -804,6 +812,7 @@ TODO:
 
     <path id="pack.bin.tool.path">
       <pathelement location="${library.jar}"/>
+      <pathelement location="${typelevel.jar}"/>
       <pathelement location="${xml.jar}"/>
       <pathelement location="${parser-combinators.jar}"/>
       <pathelement location="${actors.jar}"/>
@@ -818,6 +827,10 @@ TODO:
     <path id="pack.library.files">
       <fileset dir="${build-quick.dir}/classes/library"/>
       <fileset dir="${forkjoin-classes}"/>
+    </path>
+
+    <path id="pack.typelevel.files">
+      <fileset dir="${build-quick.dir}/classes/typelevel"/>
     </path>
 
     <path id="pack.actors.files">
@@ -866,6 +879,7 @@ TODO:
 
     <!-- DOCS -->
     <path id="docs.library.build.path">               <path refid="quick.library.build.path"/>  </path>
+    <path id="docs.typelevel.build.path">             <path refid="quick.typelevel.build.path"/> </path>
     <path id="docs.reflect.build.path">               <path refid="quick.reflect.build.path"/>  </path>
     <path id="docs.compiler.build.path">              <path refid="quick.compiler.build.path"/> </path>
     <path id="docs.scaladoc.build.path">              <path refid="quick.scaladoc.build.path"/> </path>
@@ -877,6 +891,7 @@ TODO:
     <path id="scaladoc.classpath">
       <path refid="external-modules-nocore"/>
       <pathelement location="${library.jar}"/>
+      <pathelement location="${typelevel.jar}"/>
       <pathelement location="${reflect.jar}"/>
       <pathelement location="${compiler.jar}"/>
 
@@ -892,6 +907,7 @@ TODO:
     <path id="manual.build.path">
       <path refid="external-modules-nocore"/> <!-- xml -->
       <pathelement location="${library.jar}"/>
+      <pathelement location="${typelevel.jar}"/>
       <pathelement location="${build.dir}/manmaker/classes"/>
       <path refid="aux.libs"/>  <!-- for ant -->
     </path>
@@ -917,6 +933,7 @@ TODO:
     </path>
     <path id="partest.compilation.path.core">
       <pathelement location="${library.jar}"/>
+      <pathelement location="${typelevel.jar}"/>
       <pathelement location="${reflect.jar}"/>
       <pathelement location="${compiler.jar}"/>
     </path>
@@ -940,6 +957,7 @@ TODO:
         <path refid="partest.classpath"/>
         <rsel:not><rsel:or>
           <rsel:name name="scala-library*.jar"/>
+          <rsel:name name="scala-typelevel*.jar"/>
         </rsel:or></rsel:not>
       </restrict>
       <pathelement location="${scala-xml}"/>
@@ -950,6 +968,7 @@ TODO:
         <path refid="scalacheck.classpath"/>
         <rsel:not><rsel:or>
           <rsel:name name="scala-library*.jar"/>
+          <rsel:name name="scala-typelevel*.jar"/>
           <rsel:name name="scala-compiler*.jar"/>
           <rsel:name name="scala-reflect*.jar"/>
           <rsel:name name="scala-actors*.jar"/>
@@ -976,6 +995,7 @@ TODO:
     <path id="test.osgi.compiler.build.path">
       <pathelement location="${test.osgi.classes}"/>
       <pathelement location="${build-osgi.dir}/org.scala-lang.scala-library.jar"/>
+      <pathelement location="${build-osgi.dir}/org.scala-lang.scala-typelevel.jar"/>
       <pathelement location="${build-osgi.dir}/org.scala-lang.scala-reflect.jar"/>
       <pathelement location="${build-osgi.dir}/org.scala-lang.scala-compiler.jar"/>
       <pathelement location="${build-osgi.dir}/org.scala-lang.scala-actors.jar"/>
@@ -1090,6 +1110,9 @@ TODO:
   <target name="quick.lib"        depends="quick.start">
     <staged-build with="locker"   stage="quick" project="library" srcpath="${src.dir}/library" includes="lib.rootdoc.includes"/></target>
 
+  <target name="quick.typelevel"  depends="quick.lib">
+    <staged-build with="locker"   stage="quick" project="typelevel"/> </target>
+
   <target name="quick.reflect"    depends="quick.lib">
     <staged-build with="locker"   stage="quick" project="reflect"/> </target>
 
@@ -1128,6 +1151,8 @@ TODO:
 ============================================================================ -->
   <target name="pack.lib"    depends="quick.lib, forkjoin.done"> <staged-pack project="library"/></target>
 
+  <target name="pack.typelevel" depends="quick.typelevel"> <staged-pack project="typelevel"/></target>
+
   <target name="pack.reflect" depends="quick.reflect"> <staged-pack project="reflect"/> </target>
 
   <!-- TODO modularize compiler. Remove other quick targets when they become modules. -->
@@ -1147,7 +1172,7 @@ TODO:
         <copy file="${basedir}/META-INF/MANIFEST.MF" toDir="${build-pack.dir}/META-INF"/>
         <manifest file="${build-pack.dir}/META-INF/MANIFEST.MF" mode="update">
           <attribute name="Bundle-Version" value="${version.number}"/>
-          <attribute name="Class-Path" value="scala-reflect.jar scala-library.jar"/>
+          <attribute name="Class-Path" value="scala-reflect.jar scala-library.jar scala-typelevel.jar"/>
         </manifest>
       </pre>
       <!-- JSR-223 support introduced in 2.11 -->
@@ -1166,7 +1191,7 @@ TODO:
 
   <target name="pack.scalap"     depends="quick.scalap">     <staged-pack project="scalap"/> </target>
 
-  <target name="pack.core" depends="pack.reflect, pack.comp, pack.lib"/>
+  <target name="pack.core" depends="pack.reflect, pack.comp, pack.lib, pack.typelevel"/>
 
   <!-- TODO modularize compiler: pack.scaladoc, pack.interactive, -->
   <target name="pack.modules" depends="pack.actors, pack.scalap">
@@ -1232,6 +1257,7 @@ TODO:
         </fileset>
         <filelist>
           <file name="${library.jar}"/>
+          <file name="${typelevel.jar}"/>
           <file name="${reflect.jar}"/>
           <file name="${compiler.jar}"/>
         </filelist>
@@ -1242,6 +1268,10 @@ TODO:
       <stopwatch name="osgi.core.timer"/>
       <make-bundle project="library">
         <fileset dir="${src.dir}/library"/>
+      </make-bundle>
+
+      <make-bundle project="typelevel">
+        <fileset dir="${src.dir}/typelevel"/>
       </make-bundle>
 
       <make-bundle project="reflect">
@@ -1568,6 +1598,12 @@ TODO:
     </staged-docs>
   </target>
 
+  <target name="docs.typelevel" depends="docs.start" unless="docs.skip">
+    <staged-docs project="typelevel">
+      <include name="**/*.scala"/>
+    </staged-docs>
+  </target>
+
   <target name="docs.reflect" depends="docs.start" unless="docs.skip">
     <staged-docs project="reflect">
       <include name="**/*.scala"/>
@@ -1611,7 +1647,7 @@ TODO:
     </staged-docs>
   </target>
 
-  <target name="docs.core" depends="docs.lib, docs.reflect, docs.comp" unless="docs.skip"/>
+  <target name="docs.core" depends="docs.lib, docs.typelevel, docs.reflect, docs.comp" unless="docs.skip"/>
   <!-- TODO modularize compiler:  docs.scaladoc, docs.interactive, -->
   <target name="docs.done" depends="docs.core, docs.actors, docs.scalap" unless="docs.skip"/>
 
@@ -1667,6 +1703,7 @@ MAIN DISTRIBUTION PACKAGING
     <mkdir dir="${dist.maven}"/>
 
     <mvn-package project="library"/>
+    <mvn-package project="typelevel"/>
     <mvn-package project="reflect"/>
     <mvn-package project="compiler"/>
 
@@ -1731,30 +1768,35 @@ MAIN DISTRIBUTION PACKAGING
   <target name="publish"        depends="pack-maven.done, init.maven" description="Publishes unsigned artifacts to the maven repo.">
     <deploy />
     <deploy-pom name="scala-library-all"/>
+    <deploy-jar name="scala-typelevel"/>
     <deploy-jar name="scala-dist"/>
   </target>
 
   <target name="publish.local"  depends="pack-maven.done, init.maven" description="Publishes unsigned artifacts to the local maven repo.">
     <deploy local="true"/>
     <deploy-pom name="scala-library-all" local="true"/>
+    <deploy-jar name="scala-typelevel" local="true"/>
     <deploy-jar name="scala-dist" local="true"/>
   </target>
 
   <target name="publish.signed" depends="pack-maven.done, init.maven" description="Publishes signed artifacts to the remote maven repo.">
     <deploy signed="true"/>
     <deploy-pom name="scala-library-all" signed="true"/>
+    <deploy-jar name="scala-typelevel" signed="true"/>
     <deploy-jar name="scala-dist" signed="true"/>
   </target>
 
   <target name="publish-core"   depends="pack-maven.core, init.maven">
     <deploy-one name="scala-compiler" />
     <deploy-one name="scala-library"  />
+    <deploy-one name="scala-typelevel"  />
     <deploy-one name="scala-reflect"  />
   </target>
 
   <target name="publish-core-local" depends="pack-maven.core, init.maven">
     <deploy-one name="scala-compiler" local="true"/>
     <deploy-one name="scala-library"  local="true"/>
+    <deploy-one name="scala-typelevel"  local="true"/>
     <deploy-one name="scala-reflect"  local="true"/>
   </target>
 

--- a/src/build/bnd/scala-typelevel.bnd
+++ b/src/build/bnd/scala-typelevel.bnd
@@ -1,0 +1,7 @@
+Bundle-Name: Scala Typelevel Library
+Bundle-SymbolicName: org.scala-lang.scala-typelevel
+ver: @VERSION@
+Bundle-Version: ${ver}
+Export-Package: *;version=${ver}
+Import-Package: scala.*;version="${range;[==,=+);@VERSION@}",*
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6, JavaSE-1.7

--- a/src/build/maven/scala-dist-pom.xml
+++ b/src/build/maven/scala-dist-pom.xml
@@ -36,6 +36,11 @@
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
+      <artifactId>scala-typelevel</artifactId>
+      <version>@VERSION@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
       <artifactId>scala-compiler</artifactId>
       <version>@VERSION@</version>
     </dependency>

--- a/src/build/maven/scala-typelevel-pom.xml
+++ b/src/build/maven/scala-typelevel-pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.scala-lang</groupId>
+  <artifactId>scala-typelevel</artifactId>
+  <packaging>jar</packaging>
+  <version>@VERSION@</version>
+  <name>Scala Typelevel Library</name>
+  <description>Typelevel Library for the Typelevel Scala Compiler</description>
+  <url>http://typelevel.org/</url>
+  <inceptionYear>2014</inceptionYear>
+  <organization>
+    <name>Typelevel</name>
+    <url>http://typelevel.org/</url>
+  </organization>
+  <licenses>
+    <license>
+      <name>BSD 3-Clause</name>
+      <url>http://www.scala-lang.org/license.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:git://github.com/typelevel/scala.git</connection>
+    <url>https://github.com/typelevel/scala.git</url>
+  </scm>
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/typelevel/scala/issues/</url>
+  </issueManagement>
+  <properties>
+    <info.apiURL>http://www.scala-lang.org/api/@VERSION@/</info.apiURL>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>@VERSION@</version>
+    </dependency>
+  </dependencies>
+  <developers>
+    <developer>
+      <id>typelevel</id>
+      <name>Typelevel</name>
+    </developer>
+  </developers>
+</project>

--- a/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/ContextErrors.scala
@@ -1195,7 +1195,8 @@ trait ContextErrors {
 
     import definitions._
 
-    def AmbiguousImplicitError(info1: ImplicitInfo, info2: ImplicitInfo,
+    def AmbiguousImplicitError(info1: ImplicitInfo, tree1: Tree,
+                               info2: ImplicitInfo, tree2: Tree,
                                pre1: String, pre2: String, trailer: String)
                                (isView: Boolean, pt: Type, tree: Tree)(implicit context0: Context) = {
       if (!info1.tpe.isErroneous && !info2.tpe.isErroneous) {
@@ -1231,10 +1232,20 @@ trait ContextErrors {
             if (explanation == "") "" else "\n" + explanation
           )
         }
+
+        def treeTypeArgs(annotatedTree: Tree) = annotatedTree match {
+          case TypeApply(_, args) => args.map(_.toString)
+          case _ => Nil
+        }
+
         context.issueAmbiguousError(AmbiguousImplicitTypeError(tree,
-          if (isView) viewMsg
-          else s"ambiguous implicit values:\n${coreMsg}match expected type $pt")
-        )
+          (tree1.symbol, tree2.symbol) match {
+            case (ImplicitAmbiguousMsg(msg), _) => msg.format(treeTypeArgs(tree1))
+            case (_, ImplicitAmbiguousMsg(msg)) => msg.format(treeTypeArgs(tree2))
+            case (_, _) if isView => viewMsg
+            case (_, _) => s"ambiguous implicit values:\n${coreMsg}match expected type $pt"
+          }
+        ))
       }
     }
 

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -885,7 +885,7 @@ trait Implicits {
        *   - find the most likely one
        *   - if it matches, forget about all others it improves upon
        */
-      @tailrec private def rankImplicits(pending: Infos, acc: Infos): Infos = pending match {
+      @tailrec private def rankImplicits(pending: Infos, acc: List[(SearchResult, ImplicitInfo)]): List[(SearchResult, ImplicitInfo)] = pending match {
         case Nil                          => acc
         case firstPending :: otherPending =>
           def firstPendingImproves(alt: ImplicitInfo) =
@@ -912,7 +912,7 @@ trait Implicits {
               val pendingImprovingBest = undoLog undo {
                 otherPending filterNot firstPendingImproves
               }
-              rankImplicits(pendingImprovingBest, firstPending :: acc)
+              rankImplicits(pendingImprovingBest, (newBest, firstPending) :: acc)
           }
       }
 
@@ -928,14 +928,14 @@ trait Implicits {
         // So if there is any element not improved upon by the first it is an error.
         rankImplicits(eligible, Nil) match {
           case Nil            => ()
-          case chosen :: rest =>
-            rest find (alt => !improves(chosen, alt)) match {
-              case Some(competing)  =>
-                AmbiguousImplicitError(chosen, competing, "both", "and", "")(isView, pt, tree)(context)
+          case (chosenResult, chosenInfo) :: rest =>
+            rest find { case (_, alt) => !improves(chosenInfo, alt) } match {
+              case Some((competingResult, competingInfo))  =>
+                AmbiguousImplicitError(chosenInfo, chosenResult.tree, competingInfo, competingResult.tree, "both", "and", "")(isView, pt, tree)(context)
                 return AmbiguousSearchFailure // Stop the search once ambiguity is encountered, see t4457_2.scala
               case _                =>
-                if (isView) chosen.useCountView += 1
-                else chosen.useCountArg += 1
+                if (isView) chosenInfo.useCountView += 1
+                else chosenInfo.useCountArg += 1
             }
         }
 
@@ -1448,9 +1448,9 @@ trait Implicits {
     }
   }
 
-  object ImplicitNotFoundMsg {
-    def unapply(sym: Symbol): Option[(Message)] = sym.implicitNotFoundMsg match {
-      case Some(m) => Some(new Message(sym, m))
+  class ImplicitAnnotationMsg(f: Symbol => Option[String], clazz: Symbol, annotationName: String) {
+    def unapply(sym: Symbol): Option[(Message)] = f(sym) match {
+      case Some(m) => Some(new Message(sym, m, annotationName))
       case None if sym.isAliasType =>
         // perform exactly one step of dealiasing
         // this is necessary because ClassManifests are now aliased to ClassTags
@@ -1462,39 +1462,43 @@ trait Implicits {
     // check the message's syntax: should be a string literal that may contain occurrences of the string "${X}",
     // where `X` refers to a type parameter of `sym`
     def check(sym: Symbol): Option[String] =
-      sym.getAnnotation(ImplicitNotFoundClass).flatMap(_.stringArg(0) match {
-        case Some(m) => new Message(sym, m).validate
-        case None => Some("Missing argument `msg` on implicitNotFound annotation.")
+      sym.getAnnotation(clazz).flatMap(_.stringArg(0) match {
+        case Some(m) => new Message(sym, m, annotationName).validate
+        case None => Some(s"Missing argument `msg` on $annotationName annotation.")
       })
+  }
 
+  object ImplicitNotFoundMsg extends ImplicitAnnotationMsg(_.implicitNotFoundMsg, ImplicitNotFoundClass, "implicitNotFound")
+
+  object ImplicitAmbiguousMsg extends ImplicitAnnotationMsg(_.implicitAmbiguousMsg, ImplicitAmbiguousClass, "implicitAmbiguous")
+
+  class Message(sym: Symbol, msg: String, annotationName: String) {
     // http://dcsobral.blogspot.com/2010/01/string-interpolation-in-scala-with.html
     private val Intersobralator = """\$\{\s*([^}\s]+)\s*\}""".r
 
-    class Message(sym: Symbol, msg: String) {
-      private def interpolate(text: String, vars: Map[String, String]) =
-        Intersobralator.replaceAllIn(text, (_: Regex.Match) match {
-          case Regex.Groups(v) => Regex quoteReplacement vars.getOrElse(v, "")
+    private def interpolate(text: String, vars: Map[String, String]) =
+      Intersobralator.replaceAllIn(text, (_: Regex.Match) match {
+        case Regex.Groups(v) => Regex quoteReplacement vars.getOrElse(v, "")
           // #3915: need to quote replacement string since it may include $'s (such as the interpreter's $iw)
-        })
+      })
 
-      private lazy val typeParamNames: List[String] = sym.typeParams.map(_.decodedName)
+    private lazy val typeParamNames: List[String] = sym.typeParams.map(_.decodedName)
 
-      def format(paramName: Name, paramTp: Type): String = format(paramTp.typeArgs map (_.toString))
-      def format(typeArgs: List[String]): String =
-        interpolate(msg, Map((typeParamNames zip typeArgs): _*)) // TODO: give access to the name and type of the implicit argument, etc?
+    def format(paramName: Name, paramTp: Type): String = format(paramTp.typeArgs map (_.toString))
+    def format(typeArgs: List[String]): String =
+      interpolate(msg, Map((typeParamNames zip typeArgs): _*)) // TODO: give access to the name and type of the implicit argument, etc?
 
-      def validate: Option[String] = {
-        val refs  = Intersobralator.findAllMatchIn(msg).map(_ group 1).toSet
-        val decls = typeParamNames.toSet
+    def validate: Option[String] = {
+      val refs  = Intersobralator.findAllMatchIn(msg).map(_ group 1).toSet
+      val decls = typeParamNames.toSet
 
-        (refs &~ decls) match {
-          case s if s.isEmpty => None
-          case unboundNames   =>
-            val singular = unboundNames.size == 1
-            val ess      = if (singular) "" else "s"
-            val bee      = if (singular) "is" else "are"
-            Some(s"The type parameter$ess ${unboundNames mkString ", "} referenced in the message of the @implicitNotFound annotation $bee not defined by $sym.")
-        }
+      (refs &~ decls) match {
+        case s if s.isEmpty => None
+        case unboundNames   =>
+          val singular = unboundNames.size == 1
+          val ess      = if (singular) "" else "s"
+          val bee      = if (singular) "is" else "are"
+          Some(s"The type parameter$ess ${unboundNames mkString ", "} referenced in the message of the @$annotationName annotation $bee not defined by $sym.")
       }
     }
   }

--- a/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/RefChecks.scala
@@ -1468,10 +1468,13 @@ abstract class RefChecks extends InfoTransform with scala.reflect.internal.trans
         case m: MemberDef =>
           val sym = m.symbol
           applyChecks(sym.annotations)
-          // validate implicitNotFoundMessage
-          analyzer.ImplicitNotFoundMsg.check(sym) foreach { warn =>
-            reporter.warning(tree.pos, f"Invalid implicitNotFound message for ${sym}%s${sym.locationString}%s:%n$warn")
-          }
+
+          def messageWarning(name: String)(warn: String) =
+            reporter.warning(tree.pos, f"Invalid $name message for ${sym}%s${sym.locationString}%s:%n$warn")
+
+          // validate implicitNotFoundMessage and implicitAmbiguousMessage
+          analyzer.ImplicitNotFoundMsg.check(sym) foreach messageWarning("implicitNotFound")
+          analyzer.ImplicitAmbiguousMsg.check(sym) foreach messageWarning("implicitAmbiguous")
 
         case tpt@TypeTree() =>
           if(tpt.original != null) {

--- a/src/library/scala/annotation/implicitAmbiguous.scala
+++ b/src/library/scala/annotation/implicitAmbiguous.scala
@@ -1,0 +1,6 @@
+package scala.annotation
+
+import scala.annotation.meta._
+
+@getter
+final class implicitAmbiguous(msg: String) extends scala.annotation.StaticAnnotation {}

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1091,6 +1091,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val BridgeClass                = requiredClass[scala.annotation.bridge]
     lazy val ElidableMethodClass        = requiredClass[scala.annotation.elidable]
     lazy val ImplicitNotFoundClass      = requiredClass[scala.annotation.implicitNotFound]
+    lazy val ImplicitAmbiguousClass     = requiredClass[scala.annotation.implicitAmbiguous]
     lazy val MigrationAnnotationClass   = requiredClass[scala.annotation.migration]
     lazy val ScalaStrictFPAttr          = requiredClass[scala.annotation.strictfp]
     lazy val SwitchClass                = requiredClass[scala.annotation.switch]

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1091,7 +1091,7 @@ trait Definitions extends api.StandardDefinitions {
     lazy val BridgeClass                = requiredClass[scala.annotation.bridge]
     lazy val ElidableMethodClass        = requiredClass[scala.annotation.elidable]
     lazy val ImplicitNotFoundClass      = requiredClass[scala.annotation.implicitNotFound]
-    lazy val ImplicitAmbiguousClass     = requiredClass[scala.annotation.implicitAmbiguous]
+    lazy val ImplicitAmbiguousClass     = getClassIfDefined("scala.typelevel.annotation.implicitAmbiguous")
     lazy val MigrationAnnotationClass   = requiredClass[scala.annotation.migration]
     lazy val ScalaStrictFPAttr          = requiredClass[scala.annotation.strictfp]
     lazy val SwitchClass                = requiredClass[scala.annotation.switch]

--- a/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/src/reflect/scala/reflect/internal/Symbols.scala
@@ -865,10 +865,11 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
     // string.  So this needs attention.  For now the fact that migration is
     // private[scala] ought to provide enough protection.
     def hasMigrationAnnotation = hasAnnotation(MigrationAnnotationClass)
-    def migrationMessage    = getAnnotation(MigrationAnnotationClass) flatMap { _.stringArg(0) }
-    def migrationVersion    = getAnnotation(MigrationAnnotationClass) flatMap { _.stringArg(1) }
-    def elisionLevel        = getAnnotation(ElidableMethodClass) flatMap { _.intArg(0) }
-    def implicitNotFoundMsg = getAnnotation(ImplicitNotFoundClass) flatMap { _.stringArg(0) }
+    def migrationMessage     = getAnnotation(MigrationAnnotationClass) flatMap { _.stringArg(0) }
+    def migrationVersion     = getAnnotation(MigrationAnnotationClass) flatMap { _.stringArg(1) }
+    def elisionLevel         = getAnnotation(ElidableMethodClass) flatMap { _.intArg(0) }
+    def implicitNotFoundMsg  = getAnnotation(ImplicitNotFoundClass) flatMap { _.stringArg(0) }
+    def implicitAmbiguousMsg = getAnnotation(ImplicitAmbiguousClass) flatMap { _.stringArg(0) }
 
     def isCompileTimeOnly       = hasAnnotation(CompileTimeOnlyAttr)
     def compileTimeOnlyMessage  = getAnnotation(CompileTimeOnlyAttr) flatMap (_ stringArg 0)

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -363,6 +363,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.BridgeClass
     definitions.ElidableMethodClass
     definitions.ImplicitNotFoundClass
+    definitions.ImplicitAmbiguousClass
     definitions.MigrationAnnotationClass
     definitions.ScalaStrictFPAttr
     definitions.SwitchClass

--- a/src/typelevel/scala/typelevel/annotation/implicitAmbiguous.scala
+++ b/src/typelevel/scala/typelevel/annotation/implicitAmbiguous.scala
@@ -1,4 +1,4 @@
-package scala.annotation
+package scala.typelevel.annotation
 
 import scala.annotation.meta._
 

--- a/test/files/neg/implicit-ambiguous-invalid.check
+++ b/test/files/neg/implicit-ambiguous-invalid.check
@@ -1,0 +1,7 @@
+implicit-ambiguous-invalid.scala:5: warning: Invalid implicitAmbiguous message for method neqAmbig1 in object Test:
+The type parameter B referenced in the message of the @implicitAmbiguous annotation is not defined by method neqAmbig1.
+  implicit def neqAmbig1[A] : A =!= A = null
+               ^
+error: No warnings can be incurred under -Xfatal-warnings.
+one warning found
+one error found

--- a/test/files/neg/implicit-ambiguous-invalid.flags
+++ b/test/files/neg/implicit-ambiguous-invalid.flags
@@ -1,0 +1,1 @@
+-Xfatal-warnings

--- a/test/files/neg/implicit-ambiguous-invalid.scala
+++ b/test/files/neg/implicit-ambiguous-invalid.scala
@@ -1,0 +1,6 @@
+object Test {
+  trait =!=[C, D]
+
+  @annotation.implicitAmbiguous("Could not prove ${A} =!= ${B}")
+  implicit def neqAmbig1[A] : A =!= A = null
+}

--- a/test/files/neg/implicit-ambiguous-invalid.scala
+++ b/test/files/neg/implicit-ambiguous-invalid.scala
@@ -1,6 +1,6 @@
 object Test {
   trait =!=[C, D]
 
-  @annotation.implicitAmbiguous("Could not prove ${A} =!= ${B}")
+  @typelevel.annotation.implicitAmbiguous("Could not prove ${A} =!= ${B}")
   implicit def neqAmbig1[A] : A =!= A = null
 }

--- a/test/files/neg/implicit-ambiguous.check
+++ b/test/files/neg/implicit-ambiguous.check
@@ -1,0 +1,4 @@
+implicit-ambiguous.scala:10: error: Could not prove Int =!= Int
+  implicitly[Int =!= Int]
+            ^
+one error found

--- a/test/files/neg/implicit-ambiguous.scala
+++ b/test/files/neg/implicit-ambiguous.scala
@@ -1,0 +1,11 @@
+object Test {
+  trait =!=[C, D]
+
+  implicit def neq[E, F] : E =!= F = null
+
+  @annotation.implicitAmbiguous("Could not prove ${J} =!= ${J}")
+  implicit def neqAmbig1[G, H, J] : J =!= J = null
+  implicit def neqAmbig2[I] : I =!= I = null
+
+  implicitly[Int =!= Int]
+}

--- a/test/files/neg/implicit-ambiguous.scala
+++ b/test/files/neg/implicit-ambiguous.scala
@@ -3,7 +3,7 @@ object Test {
 
   implicit def neq[E, F] : E =!= F = null
 
-  @annotation.implicitAmbiguous("Could not prove ${J} =!= ${J}")
+  @typelevel.annotation.implicitAmbiguous("Could not prove ${J} =!= ${J}")
   implicit def neqAmbig1[G, H, J] : J =!= J = null
   implicit def neqAmbig2[I] : I =!= I = null
 


### PR DESCRIPTION
Example usage:

``` scala
trait =!=[C, D]

implicit def neq[E, F] : E =!= F = null

@annotation.implicitAmbiguous("Could not prove ${J} =!= ${J}")
implicit def neqAmbig1[G, H, J] : J =!= J = null
implicit def neqAmbig2[I] : I =!= I = null

implicitly[Int =!= Int]
```

Which gives the following error:

```
implicit-ambiguous.scala:9: error: Could not prove Int =!= Int
  implicitly[Int =!= Int]
            ^
```

Better than what was previously given:

```
implicit-ambiguous.scala:9: error: ambiguous implicit values:
 both method neqAmbig1 in object Test of type [G, H, J]=> Main.$anon.Test.=!=[J,J]
 and method neqAmbig2 in object Test of type [I]=> Main.$anon.Test.=!=[I,I]
 match expected type Main.$anon.Test.=!=[Int,Int]
  implicitly[Int =!= Int]
            ^
```
