### PR TITLE
update documentation for ENSIME

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@
 /sandbox/
 /.ant-targets-build.xml
 
-# eclipse, intellij
+# eclipse, intellij, ensime
 /.classpath
 /.project
 /src/intellij/*.iml
@@ -45,6 +45,8 @@
 **/.cache
 /.idea
 /.settings
+/.ensime
+/.ensime_cache
 
 # Standard symbolic link to build/quick/bin
 /qbin

--- a/build.xml
+++ b/build.xml
@@ -267,20 +267,20 @@ TODO:
     <if><not><isset property="maven-deps-done"></isset></not><then>
       <mkdir dir="${user.home}/.m2/repository"/>
       <!-- This task has an issue where if the user directory does not exist, so we create it above. UGH. -->
-      <artifact:dependencies pathId="extra.tasks.classpath" filesetId="extra.tasks.fileset">
+      <artifact:dependencies sourcesFilesetId="sources.dependency.fileset"  pathId="extra.tasks.classpath" filesetId="extra.tasks.fileset">
         <dependency groupId="biz.aQute" artifactId="bnd" version="1.50.0"/>
       </artifact:dependencies>
 
       <!-- JUnit -->
       <property name="junit.version" value="4.10"/>
-      <artifact:dependencies pathId="junit.classpath" filesetId="junit.fileset">
+      <artifact:dependencies sourcesFilesetId="sources.dependency.fileset"  pathId="junit.classpath" filesetId="junit.fileset">
         <dependency groupId="junit" artifactId="junit" version="${junit.version}"/>
       </artifact:dependencies>
       <copy-deps project="junit"/>
 
       <!-- Pax runner -->
       <property name="pax.exam.version" value="2.6.0"/>
-      <artifact:dependencies pathId="pax.exam.classpath" filesetId="pax.exam.fileset">
+      <artifact:dependencies sourcesFilesetId="sources.dependency.fileset"  pathId="pax.exam.classpath" filesetId="pax.exam.fileset">
         <dependency groupId="org.ops4j.pax.exam" artifactId="pax-exam-container-native" version="${pax.exam.version}"/>
         <dependency groupId="org.ops4j.pax.exam" artifactId="pax-exam-junit4" version="${pax.exam.version}"/>
         <dependency groupId="org.ops4j.pax.exam" artifactId="pax-exam-link-assembly" version="${pax.exam.version}"/>
@@ -310,7 +310,7 @@ TODO:
       <prepareCross name="scalacheck"/>
 
       <!-- TODO: delay until absolutely necessary to allow minimal build, also move out partest dependency from scaladoc -->
-      <artifact:dependencies pathId="partest.classpath" filesetId="partest.fileset" versionsId="partest.versions">
+      <artifact:dependencies sourcesFilesetId="sources.dependency.fileset"  pathId="partest.classpath" filesetId="partest.fileset" versionsId="partest.versions">
         <!-- uncomment the following if you're deploying your own partest locally -->
         <!-- <localRepository path="${user.home}/.m2/repository"/> -->
         <!-- so we don't have to wait for artifacts to synch to maven central
@@ -322,12 +322,12 @@ TODO:
       </artifact:dependencies>
       <copy-deps project="partest"/>
 
-      <artifact:dependencies pathId="scalacheck.classpath" filesetId="scalacheck.fileset" versionsId="scalacheck.versions">
+      <artifact:dependencies sourcesFilesetId="sources.dependency.fileset"  pathId="scalacheck.classpath" filesetId="scalacheck.fileset" versionsId="scalacheck.versions">
         <artifact:remoteRepository refid="extra-repo"/>
         <dependency groupId="org.scalacheck"         artifactId="scalacheck${scalacheck.cross}"    version="${scalacheck.version.number}" />
       </artifact:dependencies>
 
-      <artifact:dependencies pathId="repl.deps.classpath" filesetId="repl.fileset" versionsId="repl.deps.versions">
+      <artifact:dependencies sourcesFilesetId="sources.dependency.fileset"  pathId="repl.deps.classpath" filesetId="repl.fileset" versionsId="repl.deps.versions">
         <dependency groupId="jline" artifactId="jline" version="${jline.version}"/>
       </artifact:dependencies>
       <copy-deps project="repl"/>
@@ -366,7 +366,7 @@ TODO:
       <typedef resource="aQute/bnd/ant/taskdef.properties" classpathref="extra.tasks.classpath" />
 
       <echo message="Using Scala ${starr.version} for STARR."/>
-      <artifact:dependencies pathId="starr.compiler.path" filesetId="starr.fileset">
+      <artifact:dependencies sourcesFilesetId="sources.dependency.fileset"  pathId="starr.compiler.path" filesetId="starr.fileset">
         <artifact:remoteRepository refid="extra-repo"/>
         <dependency groupId="org.scala-lang" artifactId="scala-library" version="${starr.version}"/>
         <dependency groupId="org.scala-lang" artifactId="scala-reflect" version="${starr.version}"/>
@@ -1525,10 +1525,10 @@ TODO:
     <!-- Obtain mima -->
     <mkdir dir="${bc-build.dir}"/>
     <!-- Pull down MIMA -->
-    <artifact:dependencies pathId="mima.classpath">
+    <artifact:dependencies sourcesFilesetId="sources.dependency.fileset"  pathId="mima.classpath">
       <dependency groupId="com.typesafe" artifactId="mima-reporter_2.10" version="0.1.6"/>
     </artifact:dependencies>
-    <artifact:dependencies pathId="old.bc.classpath">
+    <artifact:dependencies sourcesFilesetId="sources.dependency.fileset"  pathId="old.bc.classpath">
       <dependency groupId="org.scala-lang" artifactId="scala-library" version="${bc-reference-version}"/>
       <dependency groupId="org.scala-lang" artifactId="scala-reflect" version="${bc-reference-version}"/>
     </artifact:dependencies>

--- a/src/ensime/.ensime.SAMPLE
+++ b/src/ensime/.ensime.SAMPLE
@@ -1,17 +1,81 @@
-(
-  :disable-source-load-on-startup t
-  :disable-scala-jars-on-classpath t
-  :root-dir "c:/Projects/Kepler"
-  :sources (
-    "c:/Projects/Kepler/src/library"
-    "c:/Projects/Kepler/src/reflect"
-    "c:/Projects/Kepler/src/compiler"
-  )
-  :compile-deps (
-    "c:/Projects/Kepler/build/asm/classes"
-    "c:/Projects/Kepler/build/locker/classes/library"
-    "c:/Projects/Kepler/build/locker/classes/reflect"
-    "c:/Projects/Kepler/build/locker/classes/compiler"
-  )
-  :target "c:/Projects/Kepler/build/classes"
-)
+(:root-dir "BASE"
+ :cache-dir "BASE/.ensime_cache"
+ :name "scala"
+ :java-home "/opt/jdk1.6.0_45"
+ :reference-source-roots ("/opt/jdk1.6.0_45/src.zip")
+ :scala-version "2.11.2"
+ :subprojects (
+               (:name "asm"
+                      :depends-on-modules nil
+                      :source-roots ("BASE/src/asm")
+                      :target "BASE/build/asm/classes")
+               (:name "forkjoin"
+                      :depends-on-modules nil
+                      :source-roots ("BASE/src/forkjoin")
+                      :target "BASE/build/libs/classes/forkjoin")
+               (:name "library"
+                      :depends-on-modules ("asm" "forkjoin")
+                      :source-roots ("BASE/src/library"
+                                     "BASE/test/junit")
+                      :target "BASE/build/quick/classes/library"
+                      :test-target "BASE/build/junit/classes"
+                      :compile-deps ("M2_REPO/junit/junit/4.10/junit-4.10.jar"
+                                     "M2_REPO/org/hamcrest/hamcrest-core/1.1/hamcrest-core-1.1.jar")
+                      :reference-source-roots ("M2_REPO/junit/junit/4.10/junit-4.10-sources.jar"
+                                               "M2_REPO/org/hamcrest/hamcrest-core/1.1/hamcrest-core-1.1-sources.jar"))
+               (:name "reflect"
+                      :depends-on-modules ("library")
+                      :source-roots ("BASE/src/reflect")
+                      :target "BASE/build/quick/classes/reflect")
+               (:name "compiler"
+                      :depends-on-modules ("reflect")
+                      :source-roots ("BASE/src/compiler")
+                      :target "BASE/build/classes"
+                      :compile-deps ("M2_REPO/org/apache/ant/ant/1.8.4/ant-1.8.4.jar")
+                      :reference-source-roots ("M2_REPO/org/apache/ant/ant/1.8.4/ant-1.8.4-sources.jar"))
+               (:name "repl"
+                      :depends-on-modules ("compiler")
+                      :source-roots ("BASE/src/repl")
+                      :target "BASE/build/quick/classes/repl"
+                      :compile-deps ("M2_REPO/jline/jline/2.12/jline-2.12.jar")
+                      :reference-source-roots ("M2_REPO/jline/jline/2.12/jline-2.12-sources.jar"))
+               (:name "scalap"
+                      :depends-on-modules ("compiler")
+                      :source-roots ("BASE/src/scalap")
+                      :target "BASE/build/scalap/classes")
+               (:name "actors"
+                      :depends-on-modules ("library")
+                      :source-roots ("BASE/src/actors")
+                      :target "BASE/build/actors/classes")
+               (:name "partest"
+                      :depends-on-modules ("repl")
+                      :source-roots ("BASE/src/partest-extras"
+                                     "BASE/src/partest-javaagent")
+                      :targets ("BASE/build/quick/classes/partest-extras"
+                                "BASE/build/quick/classes/partest-javaagent")
+                      :compile-deps ("M2_REPO/com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar"
+                                     "M2_REPO/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar"
+                                     "M2_REPO/org/apache/ant/ant-launcher/1.8.4/ant-launcher-1.8.4.jar")
+                      :reference-source-roots ("M2_REPO/com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0-sources.jar"
+                                               "M2_REPO/org/scala-sbt/test-interface/1.0/test-interface-1.0-sources.jar"
+                                               "M2_REPO/org/apache/ant/ant-launcher/1.8.4/ant-launcher-1.8.4-sources.jar"))
+               (:name "scaladoc"
+                      :depends-on-modules ("partest")
+                      :source-roots ("BASE/src/scaladoc")
+                      :target "BASE/build/scaladoc/classes"
+                      :compile-deps ("M2_REPO/org/scala-lang/plugins/scala-continuations-library_2.11/1.0.2/scala-continuations-library_2.11-1.0.2.jar"
+                                     "M2_REPO/org/scala-lang/plugins/scala-continuations-plugin_2.11.2/1.0.2/scala-continuations-plugin_2.11.2-1.0.2.jar"
+                                     "M2_REPO/org/scala-lang/modules/scala-parser-combinators_2.11/1.0.2/scala-parser-combinators_2.11-1.0.2.jar"
+                                     "M2_REPO/org/scala-lang/modules/scala-swing_2.11/1.0.1/scala-swing_2.11-1.0.1.jar"
+                                     "M2_REPO/org/scala-lang/modules/scala-xml_2.11/1.0.2/scala-xml_2.11-1.0.2.jar"
+                                     )
+                      :reference-source-roots ("M2_REPO/org/scala-lang/plugins/scala-continuations-library_2.11/1.0.2/scala-continuations-library_2.11-1.0.2-sources.jar"
+                                               "M2_REPO/org/scala-lang/plugins/scala-continuations-plugin_2.11.2/1.0.2/scala-continuations-plugin_2.11.2-1.0.2-sources.jar"
+                                               "M2_REPO/org/scala-lang/modules/scala-parser-combinators_2.11/1.0.2/scala-parser-combinators_2.11-1.0.2-sources.jar"
+                                               "M2_REPO/org/scala-lang/modules/scala-swing_2.11/1.0.1/scala-swing_2.11-1.0.1-sources.jar"
+                                               "M2_REPO/org/scala-lang/modules/scala-xml_2.11/1.0.2/scala-xml_2.11-1.0.2-sources.jar"))
+               (:name "interactive"
+                      :depends-on-modules ("scaladoc")
+                      :source-roots ("BASE/src/interactive")
+                      :target "BASE/build/interactive/classes")
+               ))

--- a/src/ensime/README.md
+++ b/src/ensime/README.md
@@ -1,11 +1,48 @@
-Ensime project files
-=====================
+ENSIME
+======
 
-Rename .ensime.SAMPLE to .ensime and replace sample paths with real paths to your sources and build results.
-After that you're good to go with one of the ENSIME-enabled text editors.
+[ENSIME](https://github.com/ensime/ensime-server) provides IDE-like
+features in [GNU Emacs](http://www.gnu.org/software/emacs/) (and
+other text editors if somebody wants to write/maintain a plugin).
 
-Editors that know how to talk to ENSIME servers:
-1) Emacs via https://github.com/aemoncannon/ensime
-2) jEdit via https://github.com/djspiewak/ensime-sidekick
-3) TextMate via https://github.com/mads379/ensime.tmbundle
-4) Sublime Text 2 via https://github.com/sublimescala/sublime-ensime
+ENSIME does not compile sources to `.class` files: `ant` is still
+required to produce output.
+
+Included here is a `.ensime.SAMPLE` which can be used as the basis of
+a configuration for working on scala itself.
+
+Paths must be absolute, so you will need to customise this sample for
+your environment: after running `ant init` (to download all jars and
+sources) this should be as simple as performing a search and replace
+on `BASE` and `M2_REPO` with your paths.
+
+To speed things up and reduce memory/CPU overhead, delete the
+downstream modules that you're not interested in.
+
+Binary Compatibility
+--------------------
+
+ENSIME uses the same version of the presentation compiler as is used
+by the project, therefore a build of ENSIME for the specified
+`:scala-version` must exist.
+
+When working on maintenance branches of scala, it should be as
+simple as using the last stable release of scala (on that branch) as
+the version number. In this mode, ENSIME will expect `.class` files to
+exist in the `build/quick` (produced by a quick build).
+
+However, when working on development branches it is unlikely that a
+version of ENSIME will be available: so use the most recent stable
+release. In this case, ENSIME will fail horribly when attempting to
+read the `.class` files (e.g. the pickle format may have changed), so
+delete all the `:target` and `:targets` settings and type `C-c C-c a`
+(`ensime-typecheck-all`) when starting your session to use "source
+only" mode. It may take several minutes for typechecking to complete,
+and there will be many false negative warnings. Warnings that are a
+result of new language features cannot be fixed. For what remains,
+open up the `interactive` module and fix some bugs in the presentation
+compiler :-P
+
+NOTE: If https://github.com/ensime/ensime-server/issues/624 has been
+implemented by the time you are reading this, then you might not have
+to issue the `ensime-typecheck-all` call or tweak the `:targets`.


### PR DESCRIPTION
ENSIME support for hacking on scala seems to have rotted, so this is to bring it up to date.

(The following is answered already)

~~I have a PR https://github.com/ensime/ensime-server/pull/622 which allows me to superficially hack on the the `scala-library` after issuing an `ant` on a clean checkout. We're also discussing a few further issues that we might need to address. In any case, I need some help from seasoned scala contributors on this PR:~~
1. ~~which modules do you want to support? The previous config only supported `library`, `reflect` and `compiler` (I consider `asm` to be a module since you're compiling from source... so anything else like that is necessary)~~
2. ~~what is the dependency tree of those modules?~~
3. ~~where are your test sources associated to each module? I'm completely lost~~
4. ~~where do output classes (and test-classes) associated to each module go? (I could only find the class output for `asm`)~~
5. ~~which version of scala is supposed to be used for a given branch? e.g. does the library for 2.11 actually use 2.11 or is it bootstrapped off 2.10? (or is it just the compiler that needs to be bootstrapped?). This might imply the need to create two separate `.ensime` configurations: an ENSIME project only supports one version of scala (it has a tightly coupled in-process presentation compiler).~~
6. ~~I guess in everything pre 2.12 the official java version is 1.6.0 so you need the `forkjoin.jar`. You haven't attached the sources, can somebody please do so? (and also, is it just the library that depends on it?)~~

~~And maybe this is a can of worms, but what does one type to produce `.class` output from library/compiler/reflect in a quick dev cycle? Will it completely break everything if we add compiled library/compiler/reflect classes to the presentation compiler classpath or should we just stick to a pure full source instance?~~
