### PR TITLE
Provide syntax for type lambdas.

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -153,6 +153,20 @@ abstract class TreeBuilder {
   /** Create a tree representing the function type (argtpes) => restpe */
   def makeFunctionTypeTree(argtpes: List[Tree], restpe: Tree): Tree = gen.mkFunctionTypeTree(argtpes, restpe)
 
+  /** Create a type lambda tree */
+  def makeTypeLambdaTypeTree(argtpes: List[TypeDef], restpe: Tree): Tree =
+    SelectFromTypeTree(
+      CompoundTypeTree(
+        Template(
+          Select(Select(Ident("_root_"), "scala"), newTypeName("AnyRef")) :: Nil,
+          ValDef(Modifiers(0), "_", TypeTree(), EmptyTree),
+          TypeDef(
+            Modifiers(0),
+            newTypeName("L"),
+            argtpes,
+            restpe) :: Nil)),
+      newTypeName("L"))
+
   /** Append implicit parameter section if `contextBounds` nonempty */
   def addEvidenceParams(owner: Name, vparamss: List[List[ValDef]], contextBounds: List[Tree]): List[List[ValDef]] = {
     if (contextBounds.isEmpty) vparamss

--- a/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/TreeBuilder.scala
@@ -154,18 +154,15 @@ abstract class TreeBuilder {
   def makeFunctionTypeTree(argtpes: List[Tree], restpe: Tree): Tree = gen.mkFunctionTypeTree(argtpes, restpe)
 
   /** Create a type lambda tree */
-  def makeTypeLambdaTypeTree(argtpes: List[TypeDef], restpe: Tree): Tree =
+  def makeTypeLambdaTypeTree(argtpes: List[TypeDef], restpe: Tree): Tree = {
+    val name = freshTypeName("L")
     SelectFromTypeTree(
       CompoundTypeTree(
         Template(
           Select(Select(Ident("_root_"), "scala"), newTypeName("AnyRef")) :: Nil,
           ValDef(Modifiers(0), "_", TypeTree(), EmptyTree),
-          TypeDef(
-            Modifiers(0),
-            newTypeName("L"),
-            argtpes,
-            restpe) :: Nil)),
-      newTypeName("L"))
+          TypeDef(Modifiers(0), name, argtpes, restpe) :: Nil)), name)
+  }
 
   /** Append implicit parameter section if `contextBounds` nonempty */
   def addEvidenceParams(owner: Name, vparamss: List[List[ValDef]], contextBounds: List[Tree]): List[List[ValDef]] = {

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2520,7 +2520,11 @@ trait Types
 
     override def isHigherKinded = !typeParams.isEmpty
 
-    override def safeToString = typeParamsString(this) + resultType
+    override def safeToString: String =
+      resultType match {
+        case TypeRef(_, _, _) => typeParamsString(this) + " => " + resultType
+        case _ => typeParamsString(this) + resultType
+      }
 
     override def cloneInfo(owner: Symbol) = {
       val tparams = cloneSymbolsAtOwner(typeParams, owner)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2522,7 +2522,7 @@ trait Types
 
     override def safeToString: String =
       resultType match {
-        case TypeBounds(_, _) | ClassInfoType(_, _, _) | MethodType(_, _) | NullaryMethodType(_) =>
+        case TypeBounds(_, _) | ClassInfoType(_, _, _) | MethodType(_, _) | NullaryMethodType(_) | OverloadedType(_, _) =>
           typeParamsString(this) + resultType
         case _ =>
           typeParamsString(this) + " => " + resultType

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2522,8 +2522,10 @@ trait Types
 
     override def safeToString: String =
       resultType match {
-        case TypeRef(_, _, _) => typeParamsString(this) + " => " + resultType
-        case _ => typeParamsString(this) + resultType
+        case TypeBounds(_, _) | ClassInfoType(_, _, _) | MethodType(_, _) | NullaryMethodType(_) =>
+          typeParamsString(this) + resultType
+        case _ =>
+          typeParamsString(this) + " => " + resultType
       }
 
     override def cloneInfo(owner: Symbol) = {

--- a/test/files/neg/t2031.check
+++ b/test/files/neg/t2031.check
@@ -1,5 +1,5 @@
 t2031.scala:8: error: polymorphic expression cannot be instantiated to expected type;
- found   : [A]scala.collection.mutable.Builder[A,scala.collection.immutable.TreeSet[A]]
+ found   : [A] => scala.collection.mutable.Builder[A,scala.collection.immutable.TreeSet[A]]
  required: scala.collection.generic.CanBuildFrom[scala.collection.immutable.TreeSet[Int],Int,?]
  res0.map(x => x)(TreeSet.newBuilder)
                           ^

--- a/test/files/neg/t3224.check
+++ b/test/files/neg/t3224.check
@@ -1,5 +1,5 @@
 t3224.scala:30: error: polymorphic expression cannot be instantiated to expected type;
- found   : [T]Array[T]
+ found   : [T] => Array[T]
  required: List[?]
     println(Texts textL Array())
                              ^
@@ -19,7 +19,7 @@ t3224.scala:36: error: type mismatch;
     println(Texts textA List(1, 1));
                             ^
 t3224.scala:48: error: polymorphic expression cannot be instantiated to expected type;
- found   : [T]Array[T]
+ found   : [T] => Array[T]
  required: List[?]
     assert(size(Array()) == 0)
                      ^

--- a/test/files/neg/t4137.check
+++ b/test/files/neg/t4137.check
@@ -1,8 +1,8 @@
-t4137.scala:9: error: overriding type EPC in trait A, which equals [X1]C[X1];
+t4137.scala:9: error: overriding type EPC in trait A, which equals [X1] => C[X1];
  type EPC has incompatible type
   override type EPC = C[T]
                 ^
-t4137.scala:10: error: overriding type EPC2 in trait A, which equals [X1]C[X1];
+t4137.scala:10: error: overriding type EPC2 in trait A, which equals [X1] => C[X1];
  type EPC2 has incompatible type
   override type EPC2[X1 <: String] = C[X1]
                 ^

--- a/test/files/neg/t5580a.check
+++ b/test/files/neg/t5580a.check
@@ -1,5 +1,5 @@
 t5580a.scala:9: error: polymorphic expression cannot be instantiated to expected type;
- found   : [A]scala.collection.mutable.Set[A]
+ found   : [A] => scala.collection.mutable.Set[A]
  required: scala.collection.mutable.Map[bar,scala.collection.mutable.Set[bar]]
     if (map.get(tmp).isEmpty) map.put(tmp,collection.mutable.Set())
                                                                 ^

--- a/test/files/neg/t5580b.check
+++ b/test/files/neg/t5580b.check
@@ -1,5 +1,5 @@
 t5580b.scala:11: error: polymorphic expression cannot be instantiated to expected type;
- found   : [A]scala.collection.mutable.Set[A]
+ found   : [A] => scala.collection.mutable.Set[A]
  required: scala.collection.mutable.Map[bar,scala.collection.mutable.Set[bar]]
     if (map.get(tmp).isEmpty) map.put(tmp,collection.mutable.Set())
                                                                 ^

--- a/test/files/neg/t7872.check
+++ b/test/files/neg/t7872.check
@@ -1,10 +1,10 @@
-t7872.scala:6: error: contravariant type a occurs in covariant position in type [-a]Cov[a] of type l
+t7872.scala:6: error: contravariant type a occurs in covariant position in type [-a] => Cov[a] of type l
   type x = {type l[-a] = Cov[a]}
                  ^
-t7872.scala:8: error: covariant type a occurs in contravariant position in type [+a]Inv[a] of type l
+t7872.scala:8: error: covariant type a occurs in contravariant position in type [+a] => Inv[a] of type l
   foo[({type l[+a] = Inv[a]})#l]
              ^
-t7872.scala:5: error: contravariant type a occurs in covariant position in type [-a]Cov[a] of type l
+t7872.scala:5: error: contravariant type a occurs in covariant position in type [-a] => Cov[a] of type l
   type l[-a] = Cov[a]
        ^
 three errors found

--- a/test/files/neg/t7872b.check
+++ b/test/files/neg/t7872b.check
@@ -1,7 +1,7 @@
-t7872b.scala:8: error: contravariant type a occurs in covariant position in type [-a]List[a] of type l
+t7872b.scala:8: error: contravariant type a occurs in covariant position in type [-a] => List[a] of type l
   def oops1 = down[({type l[-a] = List[a]})#l](List('whatever: Object)).head + "oops"
                           ^
-t7872b.scala:19: error: covariant type a occurs in contravariant position in type [+a]coinv.Stringer[a] of type l
+t7872b.scala:19: error: covariant type a occurs in contravariant position in type [+a] => coinv.Stringer[a] of type l
   def oops2 = up[({type l[+a] = Stringer[a]})#l]("printed: " + _)
                         ^
 two errors found

--- a/test/files/run/reflection-idtc.check
+++ b/test/files/run/reflection-idtc.check
@@ -1,6 +1,6 @@
-[X]X
+[X] => X
 Int
 ===
-[X]Id[X]
+[X] => Id[X]
 Id[Int]
 Int

--- a/test/files/run/t6113.check
+++ b/test/files/run/t6113.check
@@ -1,1 +1,1 @@
-Foo[[X](Int, X)]
+Foo[[X] => (Int, X)]

--- a/test/files/run/t7319.check
+++ b/test/files/run/t7319.check
@@ -32,7 +32,7 @@ argument expression's type is not compatible with formal parameter type;
 
 scala> Range(1,2).toArray: Seq[_]
 <console>:11: error: polymorphic expression cannot be instantiated to expected type;
- found   : [B >: Int]Array[B]
+ found   : [B >: Int] => Array[B]
  required: Seq[_]
               Range(1,2).toArray: Seq[_]
                          ^


### PR DESCRIPTION
This commit adds a syntax for type functions that mirrors the
existing syntax for value functions. The underlying representation
for these types uses type projections, and is exactly the same
as those produced by the ({type L...})#L syntax.

Here are some examples:

  [x] => Either[String, x]
  [-x, +y] => (x, Int) => y
  [y, x] => Map[x, y]
  [x[_]] => x[Double]

This commit also changes how these types are pretty-printed, to
ensure that the type the user is shown matches the type they
would specify.

There's an interesting wrinkle around type lambda currying. It
was already possible to nest type lambdas, but this syntax makes
it much easier to do. However, these types generally don't work
properly, so they should be avoided.

Fixes #6.
