### PR TITLE
Add back the optional .type

### DIFF
--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -960,12 +960,12 @@ self =>
             wildcardType(in.skipToken())
           case tok if sip23 && isLiteralToken(tok) => // SIP-23
             // allowing an optional `.type` suffix:
-            /*val lit = literal()
+            val lit = literal()
             if (in.token == DOT && lookingAhead { in.token == TYPE }) {
               accept(DOT)
               accept(TYPE)
-            }*/
-            atPos(start){SingletonTypeTree(literal())}
+            }
+            atPos(start){SingletonTypeTree(lit)}
           case _ =>
             path(thisOK = false, typeOK = true) match {
               case r @ SingletonTypeTree(_) => r

--- a/test/files/run/sip-23-type-equality.scala
+++ b/test/files/run/sip-23-type-equality.scala
@@ -3,6 +3,6 @@ object Test extends App {
   val y: x.type = 1
 
   implicitly[x.type =:= y.type]
-  implicitly[1 =:= y.type]
-  implicitly[1 =:= x.type]
+  implicitly[1      =:= y.type]
+  implicitly[1.type =:= x.type]
 }


### PR DESCRIPTION
One thing I forgot to add back before submitting #87 – optional `.type` for literals. /cc @propensive 
