### PR TITLE
SI-4700 Add `@infix` annotation for type printing

### DIFF
--- a/src/library/scala/annotation/showAsInfix.scala
+++ b/src/library/scala/annotation/showAsInfix.scala
@@ -1,0 +1,21 @@
+package scala.annotation
+
+/**
+ * This annotation, used for two-parameter generic types makes Scala print
+ * the type using infix notation:
+ *
+ * ```
+ * scala> class &&[T, U]
+ * defined class $amp$amp
+ *
+ * scala> def foo: Int && Int = ???
+ * foo: &&[Int,Int]
+ *
+ * scala> @showAsInfix class &&[T, U]
+ * defined class $amp$amp
+ *
+ * scala> def foo: Int && Int = ???
+ * foo: Int && Int
+ * ```
+ */
+class showAsInfix extends annotation.StaticAnnotation

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1405,6 +1405,8 @@ trait Definitions extends api.StandardDefinitions {
       case _                  => false
     }
 
+    lazy val ShowAsInfixAnnotationClass = rootMirror.getClassIfDefined("scala.annotation.showAsInfix")
+
     // todo: reconcile with javaSignature!!!
     def signature(tp: Type): String = {
       def erasure(tp: Type): Type = tp match {

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -307,6 +307,9 @@ trait Types
     /** Is this type completed (i.e. not a lazy type)? */
     def isComplete: Boolean = true
 
+    /** Should this be printed as an infix type (@showAsInfix class &&[T, U])? */
+    def isShowAsInfixType: Boolean = false
+
     /** If this is a lazy type, assign a new type to `sym`. */
     def complete(sym: Symbol) {}
 
@@ -2097,6 +2100,9 @@ trait Types
         trivial = fromBoolean(!sym.isTypeParameter && pre.isTrivial && areTrivialTypes(args))
       toBoolean(trivial)
     }
+
+    override def isShowAsInfixType: Boolean = sym.hasAnnotation(ShowAsInfixAnnotationClass)
+
     private[Types] def invalidateTypeRefCaches(): Unit = {
       parentsCache = null
       parentsPeriod = NoPeriod
@@ -2345,6 +2351,14 @@ trait Types
               xs.init.mkString("(", ", ", ")") + " => " + xs.last
           }
         }
+        else if (isShowAsInfixType && args.length == 2)
+          args(0) + " " + sym.decodedName + " " +
+            (
+              if (args(1).isShowAsInfixType)
+                "(" + args(1) + ")"
+              else
+                args(1)
+            )
         else if (isTupleTypeDirect(this))
           tupleTypeString
         else if (sym.isAliasType && prefixChain.exists(_.termSymbol.isSynthetic) && (this ne dealias))

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -425,6 +425,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     definitions.hijackedCoreClasses
     definitions.symbolsNotPresentInBytecode
     definitions.isPossibleSyntheticParent
+    definitions.ShowAsInfixAnnotationClass
     definitions.abbrvTag
     definitions.numericWeight
     definitions.boxedModule

--- a/test/files/run/t4700.check
+++ b/test/files/run/t4700.check
@@ -1,0 +1,32 @@
+
+scala> import scala.annotation.showAsInfix
+import scala.annotation.showAsInfix
+
+scala> class &&[T,U]
+defined class $amp$amp
+
+scala> def foo: Int && Boolean = ???
+foo: &&[Int,Boolean]
+
+scala> @showAsInfix class ||[T,U]
+defined class $bar$bar
+
+scala> def foo: Int || Boolean = ???
+foo: Int || Boolean
+
+scala> @showAsInfix class &&[T, U]
+defined class $amp$amp
+
+scala> def foo: Int && Boolean && String = ???
+foo: Int && Boolean && String
+
+scala> def foo: Int && (Boolean && String) = ???
+foo: Int && (Boolean && String)
+
+scala> @showAsInfix type Mappy[T, U] = Map[T, U]
+defined type alias Mappy
+
+scala> def foo: Int Mappy (Boolean && String) = ???
+foo: Int Mappy (Boolean && String)
+
+scala> :quit

--- a/test/files/run/t4700.scala
+++ b/test/files/run/t4700.scala
@@ -1,0 +1,18 @@
+import scala.tools.nsc.interpreter._
+import scala.tools.partest.ReplTest
+
+object Test extends ReplTest {
+  def code = """
+    |import scala.annotation.showAsInfix
+    |class &&[T,U]
+    |def foo: Int && Boolean = ???
+    |@showAsInfix class ||[T,U]
+    |def foo: Int || Boolean = ???
+    |@showAsInfix class &&[T, U]
+    |def foo: Int && Boolean && String = ???
+    |def foo: Int && (Boolean && String) = ???
+    |@showAsInfix type Mappy[T, U] = Map[T, U]
+    |def foo: Int Mappy (Boolean && String) = ???
+    |""".stripMargin
+}
+


### PR DESCRIPTION
Please wait until the tests in the Lightbend scala pass: https://github.com/scala/scala/pull/5401

```
scala> import scala.annotation.infix
import scala.annotation.infix

scala> @infix class &&[T, U]
defined class $amp$amp

scala> def foo: Int && Boolean = ???
foo: Int && Boolean
```
