### PR TITLE
Update microsite with documentation, take 2!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/typelevel/scala.svg?branch=typelevel-readme)](https://travis-ci.org/typelevel/scala) [![Join the chat at https://gitter.im/typelevel/scala](https://badges.gitter.im/typelevel/scala.svg)](https://gitter.im/typelevel/scala?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 # Typelevel Scala
 
 ## What is this repository?

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ micrositeHomepage := "http://typelevel.org/scala"
 micrositeGithubOwner := "typelevel"
 micrositeGithubRepo := "scala"
 micrositeBaseUrl := "scala"
+micrositeDocumentationUrl := "docs"
 micrositeExtraMdFiles := Map(
   file("README.md") -> ExtraMdFileConfig(
     "index.md",

--- a/src/main/resources/microsite/data/menu.yml
+++ b/src/main/resources/microsite/data/menu.yml
@@ -1,0 +1,24 @@
+options:
+  - title: Getting Started
+    url: docs/index.html
+
+  - title: Basic structure
+    url: docs/basic_structure.html
+
+  - title: Project folders
+    url: docs/project_structure.html
+
+  - title: Compiler phases
+    url: docs/phases.html
+
+  - title: Trees
+    url: docs/trees.html
+
+  - title: Symbols
+    url: docs/symbols.html
+
+  - title: Types
+    url: docs/types.html
+
+  - title: References
+    url: docs/references.html

--- a/src/main/tut/docs/basic_structure.md
+++ b/src/main/tut/docs/basic_structure.md
@@ -6,3 +6,10 @@ title: Basic structure of the Compiler
 Understanding the basic structure
 
 WIP
+
+Want to contribute? [Edit this file](https://github.com/typelevel/scala/edit/typelevel-readme/src/main/resources/microsite/docs/basic_structure.md)
+
+
+
+
+       

--- a/src/main/tut/docs/basic_structure.md
+++ b/src/main/tut/docs/basic_structure.md
@@ -1,0 +1,8 @@
+---
+layout: docs
+title: Basic structure of the Compiler
+---
+
+Understanding the basic structure
+
+WIP

--- a/src/main/tut/docs/index.md
+++ b/src/main/tut/docs/index.md
@@ -1,0 +1,23 @@
+---
+layout: docs
+title: Getting Started
+---
+
+The description part is intended as a guide for programmers seeking to understand the structure,
+and operation of the compiler, and its implementation. Some of its aspects are the following ones:
+
+Some of these contents provide an overview of the compiler code and operation, and the organisation of 
+the project. 
+
+* [Basic structure of the Scala Compiler](./basic_structure.html)
+* [Project folder structure](./project_structure.html)
+* [Compiler phases](./phases.html)
+
+Some contents are specifically dedicated to the key data structures in the compiler that 
+represents elements of the Scala language. 
+
+* [Trees](./trees.html)
+* [Symbols](./symbols.html)
+* [Types](./types.html)
+
+

--- a/src/main/tut/docs/index.md
+++ b/src/main/tut/docs/index.md
@@ -20,4 +20,4 @@ represents elements of the Scala language.
 * [Symbols](./symbols.html)
 * [Types](./types.html)
 
-
+If you want to contribute, you can easily do so via edit links present at the bottom of the pages [like this one](https://github.com/typelevel/scala/edit/typelevel-readme/src/main/resources/microsite/docs/index.md)

--- a/src/main/tut/docs/phases.md
+++ b/src/main/tut/docs/phases.md
@@ -1,0 +1,401 @@
+---
+layout: docs
+title: Compiler Phases
+---
+
+The Scala compiler has to do a lot of work to turn your code into jvm bytecode that can be executed. For several reasons, this work is broken into steps which are executed sequentially, the so called *phases* of the compiler.
+
+## The Phases
+
+If you want to see the phases listed, simply run in your terminal:
+
+```scala
+$ scalac -Xshow-phases
+Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
+
+    phase name  id  description
+    ----------  --  -----------
+        parser   1  parse source into ASTs, perform simple desugaring
+         namer   2  resolve names, attach symbols to named trees
+packageobjects   3  load package objects
+         typer   4  the meat and potatoes: type the trees
+        patmat   5  translate match expressions
+superaccessors   6  add super accessors in traits and nested classes
+    extmethods   7  add extension methods for inline classes
+       pickler   8  serialize symbol tables
+     refchecks   9  reference/override checking, translate nested objects
+       uncurry  10  uncurry, translate function values to anonymous classes
+     tailcalls  11  replace tail calls by jumps
+    specialize  12  specialized-driven class and method specialization
+ explicitouter  13  this refs to outer pointers
+       erasure  14  erase types, add interfaces for traits
+   posterasure  15  clean up erased inline classes
+      lazyvals  16  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  17  move nested functions to top level
+  constructors  18  move field definitions into constructors
+       flatten  19  eliminate inner classes
+         mixin  20  mixin composition
+       cleanup  21  platform-specific cleanups, generate reflective calls
+    delambdafy  22  remove lambdas
+         icode  23  generate portable intermediate code
+           jvm  24  generate JVM bytecode
+      terminal  25  the last phase during a compilation run
+```
+
+As you can see above, at the time of this writing the compiler uses 25 phases that start with a *parser* of the code and end with the *terminal* phase, that ends the compilation.
+
+Please note that the reality of the compiler is not as clean as this documentation would have you believe. Due to efficiency and other concerns, some phases are intertwined and they should be considered a single phase in itself. In other cases some phases do more than advertised.
+
+### Phases in the Compiler
+
+If you open your compiler codebase and go to class `Global`, line 405, you will see:
+
+```scala
+ // phaseName = "parser"
+  lazy val syntaxAnalyzer = new {
+    val global: Global.this.type = Global.this
+  } with SyntaxAnalyzer {
+    val runsAfter = List[String]()
+    val runsRightAfter = None
+    override val initial = true
+  }
+```
+
+This corresponds to the first phase of the compiler, `parser`. All the phases are defined as `lazy val`, in order, after this entry. 
+
+If you want to learn more about a specific phase you can always go to the class implementing it. In the example above, that would be `SyntaxAnalyzer`. Most of the phases have documentation that explains the function of the phase.
+
+Some things that may not be obvious from reading the documentation of the phases, but are relevant:
+
+* `parser`, the very first phase, tackles a lot of syntactic sugar. For example, at the end of this phase *for-comprehensions* will have been transformed into a series of *flatMap*, *map*, and *filter*.
+* `namer`, `packageobjects`, and `typer` (phases 2,3, and 4) are effectively a single phase. Although split into 3 elements for implementation reasons, the dependencies between them means you can consider it one.
+* After `typer` (phase 4) completes, all the typechecking has been completed. For example, any error due to Type classes missing an implicit implementation will happen at this stage. The remaining 20 phases work with code that type-checks. Guaranteed ;)
+* `pickler` (phase 8) generates attributes for class files which are later on used for compilation against binaries. This is what allows you to use a certain jar file as a library without having to bring the source code of the library along.
+* `uncurry` (phase 10) turns functions (like `val f: Int => Int`) to anonymous classes. In JVM 8 this benefits from new structures introduced to work with lambdas.
+* `lambalift` (phase 17) lifts nested functions outside of methods, a different task that `uncurry`
+* `constructors` (phase 18) generates the constructors for the classes. Keep in mind Scala constructors are very different to the ones expected by the jvm (for instance any expression in the body of a class is executed during construction) so there' quite a bit going on in this phase.
+
+## Example
+
+If we talk about phases we want to mention the `-Xprint` flag in `scalac`. This flag allows you to see the differences between phases.
+
+To test it, create a file with the following code:
+
+```scala
+class Foo{
+  val i = 23
+  val j = "blah"
+  val k = i+j
+
+  def wibble = {
+    for(c <- k) yield c*2
+  }
+}
+```
+
+and compile it with:
+
+```bash
+$ scalac -Xprint:all <youfile>.scala
+```
+
+You will see the compiler outputs the code as it's seen after each phase that modified something. For example the output will show that after the parser phase the output looks like:
+
+```scala
+[[syntax trees at end of                    parser]] // sample.scala
+package <empty> {
+  class Foo extends scala.AnyRef {
+    def <init>() = {
+      super.<init>();
+      ()
+    };
+    val i = 23;
+    val j = "blah";
+    val k = i.$plus(j);
+    def wibble = k.map(((c) => c.$times(2)))
+  }
+}
+```
+
+You can notice the class is now inside a package `empty` as we didn't declare any package. You can see a method `<init>` that acts like a pseudo-constructor has been added, the `+` operation assigned to `k` has been expanded to a method `$plus`, and the for comprehension of `wibble` has been expanded to a `map` call.
+	
+Quite a lot has changed in just the first phase :) After typing finishes we get the following output:
+
+```scala
+[[syntax trees at end of                     namer]] // sample.scala: tree is unchanged since parser
+[[syntax trees at end of            packageobjects]] // sample.scala: tree is unchanged since parser
+[[syntax trees at end of                     typer]] // sample.scala
+package <empty> {
+  class Foo extends scala.AnyRef {
+    def <init>(): Foo = {
+      Foo.super.<init>();
+      ()
+    };
+    private[this] val i: Int = 23;
+    <stable> <accessor> def i: Int = Foo.this.i;
+    private[this] val j: String = "blah";
+    <stable> <accessor> def j: String = Foo.this.j;
+    private[this] val k: String = Foo.this.i.+(Foo.this.j);
+    <stable> <accessor> def k: String = Foo.this.k;
+    def wibble: scala.collection.immutable.IndexedSeq[Int] = scala.this.Predef.augmentString(Foo.this.k).map[Int, scala.collection.immutable.IndexedSeq[Int]](((c: Char) => c.*(2)))(scala.this.Predef.fallbackStringCanBuildFrom[Int])
+  }
+}
+```
+
+The main difference is that types are assigned. For example our `val i` has type `Int`, as do the other `val` of `def` in the class. We can also see the synthetic methods added to access the values of `i`, `j`, and `k`. 
+
+You can experiment around with your own files to see changes in the output of `scalac`. A warning though, avoid using `extends App` constructs as the compiler treats them in a specific way and that may clutter your output.
+
+The full output for the example above follows:
+
+```scala
+ scalac -Xprint:all sample.scala 
+Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
+[[syntax trees at end of                    parser]] // sample.scala
+package <empty> {
+  class Foo extends scala.AnyRef {
+    def <init>() = {
+      super.<init>();
+      ()
+    };
+    val i = 23;
+    val j = "blah";
+    val k = i.$plus(j);
+    def wibble = k.map(((c) => c.$times(2)))
+  }
+}
+
+[[syntax trees at end of                     namer]] // sample.scala: tree is unchanged since parser
+[[syntax trees at end of            packageobjects]] // sample.scala: tree is unchanged since parser
+[[syntax trees at end of                     typer]] // sample.scala
+package <empty> {
+  class Foo extends scala.AnyRef {
+    def <init>(): Foo = {
+      Foo.super.<init>();
+      ()
+    };
+    private[this] val i: Int = 23;
+    <stable> <accessor> def i: Int = Foo.this.i;
+    private[this] val j: String = "blah";
+    <stable> <accessor> def j: String = Foo.this.j;
+    private[this] val k: String = Foo.this.i.+(Foo.this.j);
+    <stable> <accessor> def k: String = Foo.this.k;
+    def wibble: scala.collection.immutable.IndexedSeq[Int] = scala.this.Predef.augmentString(Foo.this.k).map[Int, scala.collection.immutable.IndexedSeq[Int]](((c: Char) => c.*(2)))(scala.this.Predef.fallbackStringCanBuildFrom[Int])
+  }
+}
+
+[[syntax trees at end of                    patmat]] // sample.scala: tree is unchanged since typer
+[[syntax trees at end of            superaccessors]] // sample.scala: tree is unchanged since typer
+[[syntax trees at end of                extmethods]] // sample.scala: tree is unchanged since typer
+[[syntax trees at end of                   pickler]] // sample.scala: tree is unchanged since typer
+[[syntax trees at end of                 refchecks]] // sample.scala: tree is unchanged since typer
+[[syntax trees at end of                   uncurry]] // sample.scala
+package <empty> {
+  class Foo extends Object {
+    def <init>(): Foo = {
+      Foo.super.<init>();
+      ()
+    };
+    private[this] val i: Int = 23;
+    <stable> <accessor> def i(): Int = Foo.this.i;
+    private[this] val j: String = "blah";
+    <stable> <accessor> def j(): String = Foo.this.j;
+    private[this] val k: String = Foo.this.i().+(Foo.this.j());
+    <stable> <accessor> def k(): String = Foo.this.k;
+    def wibble(): scala.collection.immutable.IndexedSeq[Int] = scala.this.Predef.augmentString(Foo.this.k()).map[Int, scala.collection.immutable.IndexedSeq[Int]]({
+      @SerialVersionUID(value = 0) final <synthetic> class $anonfun extends scala.runtime.AbstractFunction1[Char,Int] with Serializable {
+        def <init>(): <$anon: Char => Int> = {
+          $anonfun.super.<init>();
+          ()
+        };
+        final def apply(c: Char): Int = c.*(2)
+      };
+      (new <$anon: Char => Int>(): Char => Int)
+    }, scala.this.Predef.fallbackStringCanBuildFrom[Int]())
+  }
+}
+
+[[syntax trees at end of                 tailcalls]] // sample.scala: tree is unchanged since uncurry
+[[syntax trees at end of                specialize]] // sample.scala: tree is unchanged since uncurry
+[[syntax trees at end of             explicitouter]] // sample.scala
+package <empty> {
+  class Foo extends Object {
+    def <init>(): Foo = {
+      Foo.super.<init>();
+      ()
+    };
+    private[this] val i: Int = 23;
+    <stable> <accessor> def i(): Int = Foo.this.i;
+    private[this] val j: String = "blah";
+    <stable> <accessor> def j(): String = Foo.this.j;
+    private[this] val k: String = Foo.this.i().+(Foo.this.j());
+    <stable> <accessor> def k(): String = Foo.this.k;
+    def wibble(): scala.collection.immutable.IndexedSeq[Int] = scala.this.Predef.augmentString(Foo.this.k()).map[Int, scala.collection.immutable.IndexedSeq[Int]]({
+      @SerialVersionUID(value = 0) final <synthetic> class $anonfun extends scala.runtime.AbstractFunction1[Char,Int] with Serializable {
+        def <init>($outer: Foo.this.type): <$anon: Char => Int> = {
+          $anonfun.super.<init>();
+          ()
+        };
+        final def apply(c: Char): Int = c.*(2);
+        <synthetic> <paramaccessor> <artifact> private[this] val $outer: Foo.this.type = _;
+        <synthetic> <stable> <artifact> def $outer(): Foo.this.type = $anonfun.this.$outer
+      };
+      (new <$anon: Char => Int>(Foo.this): Char => Int)
+    }, scala.this.Predef.fallbackStringCanBuildFrom[Int]())
+  }
+}
+
+[[syntax trees at end of                   erasure]] // sample.scala
+package <empty> {
+  class Foo extends Object {
+    def <init>(): Foo = {
+      Foo.super.<init>();
+      ()
+    };
+    private[this] val i: Int = 23;
+    <stable> <accessor> def i(): Int = Foo.this.i;
+    private[this] val j: String = "blah";
+    <stable> <accessor> def j(): String = Foo.this.j;
+    private[this] val k: String = Foo.this.i().+(Foo.this.j());
+    <stable> <accessor> def k(): String = Foo.this.k;
+    def wibble(): scala.collection.immutable.IndexedSeq = new collection.immutable.StringOps(scala.this.Predef.augmentString(Foo.this.k()).$asInstanceOf[String]()).map({
+  @SerialVersionUID(value = 0) final <synthetic> class $anonfun extends scala.runtime.AbstractFunction1 with Serializable {
+    def <init>($outer: Foo): <$anon: Function1> = {
+      $anonfun.super.<init>();
+      ()
+    };
+    final def apply(c: Char): Int = c.*(2);
+    <synthetic> <paramaccessor> <artifact> private[this] val $outer: Foo = _;
+    <synthetic> <stable> <artifact> def $outer(): Foo = $anonfun.this.$outer;
+    final <bridge> <artifact> def apply(v1: Object): Object = scala.Int.box($anonfun.this.apply(unbox(v1)))
+  };
+  (new <$anon: Function1>(Foo.this): Function1)
+}, scala.this.Predef.fallbackStringCanBuildFrom()).$asInstanceOf[scala.collection.immutable.IndexedSeq]()
+  }
+}
+
+[[syntax trees at end of               posterasure]] // sample.scala
+package <empty> {
+  class Foo extends Object {
+    def <init>(): Foo = {
+      Foo.super.<init>();
+      ()
+    };
+    private[this] val i: Int = 23;
+    <stable> <accessor> def i(): Int = Foo.this.i;
+    private[this] val j: String = "blah";
+    <stable> <accessor> def j(): String = Foo.this.j;
+    private[this] val k: String = Foo.this.i().+(Foo.this.j());
+    <stable> <accessor> def k(): String = Foo.this.k;
+    def wibble(): scala.collection.immutable.IndexedSeq = new collection.immutable.StringOps(scala.this.Predef.augmentString(Foo.this.k())).map({
+  @SerialVersionUID(value = 0) final <synthetic> class $anonfun extends scala.runtime.AbstractFunction1 with Serializable {
+    def <init>($outer: Foo): <$anon: Function1> = {
+      $anonfun.super.<init>();
+      ()
+    };
+    final def apply(c: Char): Int = c.*(2);
+    <synthetic> <paramaccessor> <artifact> private[this] val $outer: Foo = _;
+    <synthetic> <stable> <artifact> def $outer(): Foo = $anonfun.this.$outer;
+    final <bridge> <artifact> def apply(v1: Object): Object = scala.Int.box($anonfun.this.apply(unbox(v1)))
+  };
+  (new <$anon: Function1>(Foo.this): Function1)
+}, scala.this.Predef.fallbackStringCanBuildFrom()).$asInstanceOf[scala.collection.immutable.IndexedSeq]()
+  }
+}
+
+[[syntax trees at end of                  lazyvals]] // sample.scala: tree is unchanged since posterasure
+[[syntax trees at end of                lambdalift]] // sample.scala
+package <empty> {
+  class Foo extends Object {
+    def <init>(): Foo = {
+      Foo.super.<init>();
+      ()
+    };
+    private[this] val i: Int = 23;
+    <stable> <accessor> def i(): Int = Foo.this.i;
+    private[this] val j: String = "blah";
+    <stable> <accessor> def j(): String = Foo.this.j;
+    private[this] val k: String = Foo.this.i().+(Foo.this.j());
+    <stable> <accessor> def k(): String = Foo.this.k;
+    def wibble(): scala.collection.immutable.IndexedSeq = new collection.immutable.StringOps(scala.this.Predef.augmentString(Foo.this.k())).map({
+  (new <$anon: Function1>(Foo.this): Function1)
+}, scala.this.Predef.fallbackStringCanBuildFrom()).$asInstanceOf[scala.collection.immutable.IndexedSeq]();
+    @SerialVersionUID(value = 0) final <synthetic> class $anonfun$wibble$1 extends scala.runtime.AbstractFunction1 with Serializable {
+      def <init>($outer: Foo): <$anon: Function1> = {
+        $anonfun$wibble$1.super.<init>();
+        ()
+      };
+      final def apply(c: Char): Int = c.*(2);
+      <synthetic> <paramaccessor> <artifact> private[this] val $outer: Foo = _;
+      <synthetic> <stable> <artifact> def $outer(): Foo = $anonfun$wibble$1.this.$outer;
+      final <bridge> <artifact> def apply(v1: Object): Object = scala.Int.box($anonfun$wibble$1.this.apply(scala.Char.unbox(v1)))
+    }
+  }
+}
+
+[[syntax trees at end of              constructors]] // sample.scala
+package <empty> {
+  class Foo extends Object {
+    private[this] val i: Int = _;
+    <stable> <accessor> def i(): Int = Foo.this.i;
+    private[this] val j: String = _;
+    <stable> <accessor> def j(): String = Foo.this.j;
+    private[this] val k: String = _;
+    <stable> <accessor> def k(): String = Foo.this.k;
+    def wibble(): scala.collection.immutable.IndexedSeq = new collection.immutable.StringOps(scala.this.Predef.augmentString(Foo.this.k())).map({
+  (new <$anon: Function1>(Foo.this): Function1)
+}, scala.this.Predef.fallbackStringCanBuildFrom()).$asInstanceOf[scala.collection.immutable.IndexedSeq]();
+    @SerialVersionUID(value = 0) final <synthetic> class $anonfun$wibble$1 extends scala.runtime.AbstractFunction1 with Serializable {
+      final def apply(c: Char): Int = c.*(2);
+      final <bridge> <artifact> def apply(v1: Object): Object = scala.Int.box($anonfun$wibble$1.this.apply(scala.Char.unbox(v1)));
+      def <init>($outer: Foo): <$anon: Function1> = {
+        $anonfun$wibble$1.super.<init>();
+        ()
+      }
+    };
+    def <init>(): Foo = {
+      Foo.super.<init>();
+      Foo.this.i = 23;
+      Foo.this.j = "blah";
+      Foo.this.k = Foo.this.i().+(Foo.this.j());
+      ()
+    }
+  }
+}
+
+[[syntax trees at end of                   flatten]] // sample.scala
+package <empty> {
+  class Foo extends Object {
+    private[this] val i: Int = _;
+    <stable> <accessor> def i(): Int = Foo.this.i;
+    private[this] val j: String = _;
+    <stable> <accessor> def j(): String = Foo.this.j;
+    private[this] val k: String = _;
+    <stable> <accessor> def k(): String = Foo.this.k;
+    def wibble(): scala.collection.immutable.IndexedSeq = new collection.immutable.StringOps(scala.this.Predef.augmentString(Foo.this.k())).map({
+  (new <$anon: Function1>(Foo.this): Function1)
+}, scala.this.Predef.fallbackStringCanBuildFrom()).$asInstanceOf[scala.collection.immutable.IndexedSeq]();
+    def <init>(): Foo = {
+      Foo.super.<init>();
+      Foo.this.i = 23;
+      Foo.this.j = "blah";
+      Foo.this.k = Foo.this.i().+(Foo.this.j());
+      ()
+    }
+  };
+  @SerialVersionUID(value = 0) final <synthetic> class anonfun$wibble$1 extends scala.runtime.AbstractFunction1 with Serializable {
+    final def apply(c: Char): Int = c.*(2);
+    final <bridge> <artifact> def apply(v1: Object): Object = scala.Int.box(anonfun$wibble$1.this.apply(scala.Char.unbox(v1)));
+    def <init>($outer: Foo): <$anon: Function1> = {
+      anonfun$wibble$1.super.<init>();
+      ()
+    }
+  }
+}
+
+[[syntax trees at end of                     mixin]] // sample.scala: tree is unchanged since flatten
+[[syntax trees at end of                   cleanup]] // sample.scala: tree is unchanged since flatten
+[[syntax trees at end of                delambdafy]] // sample.scala: tree is unchanged since flatten
+[[syntax trees at end of                     icode]] // sample.scala: tree is unchanged since flatten
+[[syntax trees at end of                       jvm]] // sample.scala: tree is unchanged since flatten
+```

--- a/src/main/tut/docs/phases.md
+++ b/src/main/tut/docs/phases.md
@@ -399,3 +399,5 @@ package <empty> {
 [[syntax trees at end of                     icode]] // sample.scala: tree is unchanged since flatten
 [[syntax trees at end of                       jvm]] // sample.scala: tree is unchanged since flatten
 ```
+
+Want to contribute? [Edit this file](https://github.com/typelevel/scala/edit/typelevel-readme/src/main/resources/microsite/docs/phases.md)

--- a/src/main/tut/docs/project_structure.md
+++ b/src/main/tut/docs/project_structure.md
@@ -1,0 +1,115 @@
+---
+layout: docs
+title: Project Folder Structure
+---
+
+Once you [clone](https://github.com/typelevel/scala/) the compiler project (*hint:* ensure you are in a branch with the compiler code, not a documentation branch) you will see several folders and files. 
+
+## Repository structure
+
+Your starting point should be the `README.md` file at the root, which describes the project a bit more. This file contains a description of the project structure, which we reproduce below:
+
+```
+scala/
++--build.sbt                 The main sbt build script
++--build.xml                 The deprecated Ant build script
++--pull-binary-libs.sh       Pulls artifacts from remote repository, used by build
++--lib/                      Pre-compiled libraries for the build
++--src/                      All sources
+   +---/compiler             Scala Compiler
+   +---/library              Scala Standard Library
+   +---/library-aux          Set of files for bootstrapping and documentation
+   +---/reflect              Scala Reflection
+   +---/repl                 REPL source
+   +---/scaladoc             Scaladoc source
+   +---/scalap               Scalap source   
+   +---/eclipse              Eclipse project files
+   +---/ensime               Ensime project templates
+   +---/intellij             IntelliJ project templates
+   +---...                   other folders like 'manual', etc
++--spec/                     The Scala language specification
++--scripts/                  Scripts for the CI jobs (including building releases)
++--test/                     The Scala test suite
+   +---/benchmarks           Benchmark tests using JMH
+   +---/files                Partest tests
+   +---/junit                JUnit tests
+   +---...                   Other folders like 'flaky' for flaky tests, etc
+   partest                   Script to launch Partest from command line
++--build/                    [Generated] Build output directory
+```
+
+
+Relevant folders when working with the Scala compiler:
+
+* **src**: source of the compiler. Also contains several IDE specific folders (ensime, eclipse, intellij), as well as the source code for tools like `scaladoc` and `scalap`
+* **test**: scala test suite. You may want to focus on the partest side (/files) as well as `junit` and `benchmarks`, for a start
+
+Folders of certain interest:
+
+* **spec**: the Scala specification, as a Jekyll project. You can see it published online at [http://www.scala-lang.org/files/archive/spec/](http://www.scala-lang.org/files/archive/spec/) (select the relevant version to see HTML docs)
+* **tools**: set of utility bash scripts, for example `scaladoc-diff` to see changes on Scaladoc
+
+The following folders and files can be ignored when you start working with the Scala compiler as they are not relevant at this stage:
+
+* **doc**: contains licenses for the project
+* **docs**: contains some TODO tasks and notes. Not updated for a long while, doubtful to be relevant anymore
+* **lib**: contains sha1 signatures for some jar files used in the project, for example the `ant-dotnet` jar to provide Scala support on .Net
+* **META-INF**: contains Manifest file for the project
+* **project**: contains helpers for the Scala build configuration. The project is using a standard `build.sbt` file, located at the root of the project
+* **scripts**: used for CI 
+
+
+## Compiler's Build Process
+
+One of the first tasks you want to do is to build the compiler, as a full compile from scratch may take a while. This will allow you to work with the compiler codebase using incremental compilation, which will reduce the build times substantially.
+
+Compiling the project has no mystery, as we are working with a standard [SBT project](http://www.scala-sbt.org/). This means you want to open a terminal at the root of the project and run `sbt`:
+
+```scala
+$ sbt
+Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8
+[info] Loading global plugins from /Users/villegap/.sbt/0.13/plugins
+[info] Loading project definition from /Users/villegap/Dropbox/Projectes/typelevel-scala/project/project
+[info] Loading project definition from /Users/villegap/Dropbox/Projectes/typelevel-scala/project
+[info] Updating {file:/Users/villegap/Dropbox/Projectes/typelevel-scala/project/}typelevel-scala-build...
+[info] Resolving org.fusesource.jansi#jansi;1.4 ...
+[info] Done updating.
+[info] *** Welcome to the sbt build definition for Scala! ***
+[info] Check README.md for more information.
+> 
+```
+
+Note the output above corresponds to my local version at the time of this entry, yours may vary accordingly. 
+
+Once in `sbt`, run `compile`. The first time this may take several minutes, depending on your computer specifications.
+
+```scala
+> compile
+[info] Updating {file:/Users/villegap/Dropbox/Projectes/typelevel-scala/}library...
+[info] Updating {file:/Users/villegap/Dropbox/Projectes/typelevel-scala/}root...
+[info] Updating {file:/Users/villegap/Dropbox/Projectes/typelevel-scala/}bootstrap...
+[info] Done updating.
+[info] Resolving org.scala-lang#scala-library;2.12.0-M5 ...
+
+[... several entries more where sbt resolves dependencies ...]
+[warn] there were 38 deprecation warnings (since 2.10.0)
+[warn] there were 25 deprecation warnings (since 2.11.0)
+[warn] there were 45 deprecation warnings (since 2.12.0)
+[warn] there were 10 deprecation warnings (since 2.12.0-M2)
+[warn] there were 118 deprecation warnings in total; re-run with -deprecation for details
+[warn] 5 warnings found
+[info] Compiling 157 Scala sources to /Users/villegap/Dropbox/Projectes/typelevel-scala/build/quick/classes/reflect...
+
+[... more deprecation warnings and compilation of other source files ...]
+[info] /Users/villegap/Dropbox/Projectes/typelevel-scala/test/junit/scala/tools/testing/ClearAfterClass.java: /Users/villegap/Dropbox/Projectes/typelevel-scala/test/junit/scala/tools/testing/ClearAfterClass.java uses unchecked or unsafe operations.
+[info] /Users/villegap/Dropbox/Projectes/typelevel-scala/test/junit/scala/tools/testing/ClearAfterClass.java: Recompile with -Xlint:unchecked for details.
+[warn] there was one deprecation warning (since 2.10.0)
+[warn] there were two deprecation warnings (since 2.10.1)
+[warn] there were 15 deprecation warnings (since 2.11.0)
+[warn] there were three deprecation warnings (since 2.11.8)
+[warn] there were 21 deprecation warnings in total; re-run with -deprecation for details
+[warn] 5 warnings found
+[success] Total time: 263 s, completed 21-Nov-2016 18:51:37
+```
+
+Once it finishes, you are ready to start hacking the compiler. For more information on the initial compilation you may want to read [Miles Sabin's post](https://milessabin.com/blog/2016/05/13/scalac-hacking/) on working with the compiler, if you haven't already.

--- a/src/main/tut/docs/project_structure.md
+++ b/src/main/tut/docs/project_structure.md
@@ -113,3 +113,5 @@ Once in `sbt`, run `compile`. The first time this may take several minutes, depe
 ```
 
 Once it finishes, you are ready to start hacking the compiler. For more information on the initial compilation you may want to read [Miles Sabin's post](https://milessabin.com/blog/2016/05/13/scalac-hacking/) on working with the compiler, if you haven't already.
+
+Want to contribute? [Edit this file](https://github.com/typelevel/scala/edit/typelevel-readme/src/main/resources/microsite/docs/project_structure.md)

--- a/src/main/tut/docs/references.md
+++ b/src/main/tut/docs/references.md
@@ -1,0 +1,19 @@
+---
+layout: docs
+title: References
+---
+
+We wrote this documentation from our experience on reading, developing, or debugging, some forked 
+variants of the Scala compiler. 
+
+We would like to thank here those who have written, or given talks, about the inner workings and 
+structure of the Scala Compiler and its variants. 
+
+### Video presentations
+
+* Chris Birchall, [A Deep Dive into Scalac](https://www.youtube.com/watch?v=2742pWdUm6c). 
+  In Scala World, Penrith (UK), September 2015. This a good description of the compiler itself.
+
+### Web logs
+
+* [Miles Sabin](https://github.com/milessabin), [Hacking on scalac — 0 to PR in an hour](https://milessabin.com/blog/2016/05/13/scalac-hacking/). An excellent introduction to working with the Scala compiler.

--- a/src/main/tut/docs/references.md
+++ b/src/main/tut/docs/references.md
@@ -17,3 +17,5 @@ structure of the Scala Compiler and its variants.
 ### Web logs
 
 * [Miles Sabin](https://github.com/milessabin), [Hacking on scalac — 0 to PR in an hour](https://milessabin.com/blog/2016/05/13/scalac-hacking/). An excellent introduction to working with the Scala compiler.
+
+Want to contribute? [Edit this file](https://github.com/typelevel/scala/edit/typelevel-readme/src/main/resources/microsite/docs/references.md)

--- a/src/main/tut/docs/symbols.md
+++ b/src/main/tut/docs/symbols.md
@@ -1,0 +1,8 @@
+---
+layout: docs
+title: Symbols
+---
+
+Symbols in scalac
+
+WIP

--- a/src/main/tut/docs/symbols.md
+++ b/src/main/tut/docs/symbols.md
@@ -6,3 +6,5 @@ title: Symbols
 Symbols in scalac
 
 WIP
+
+Want to contribute? [Edit this file](https://github.com/typelevel/scala/edit/typelevel-readme/src/main/resources/microsite/docs/symbols.md)

--- a/src/main/tut/docs/symbols.md
+++ b/src/main/tut/docs/symbols.md
@@ -3,8 +3,6 @@ layout: docs
 title: Symbols
 ---
 
-Symbols in scalac
-
-WIP
+The official documentation of the compiler has a great section explaining [Symbols](http://docs.scala-lang.org/overviews/reflection/symbols-trees-types.html).
 
 Want to contribute? [Edit this file](https://github.com/typelevel/scala/edit/typelevel-readme/src/main/resources/microsite/docs/symbols.md)

--- a/src/main/tut/docs/trees.md
+++ b/src/main/tut/docs/trees.md
@@ -1,0 +1,15 @@
+---
+layout: docs
+title: Trees
+---
+
+This page describes the Scala [AST]() and its implementation within the Scala compiler code. 
+
+The AST is designed to capture the syntactic constructs of the Scala Programming Language, 
+as described in the [language specification](https://www.scala-lang.org/files/archive/spec/2.12/13-syntax-summary.html).
+
+The implementation of the Tree is encoded in [this file](https://github.com/scala/scala/blob/2.13.x/src/reflect/scala/reflect/internal/Trees.scala) 
+
+The AST is organised in a series of traits and self-types, which follows the following structure: 
+
+WIP

--- a/src/main/tut/docs/trees.md
+++ b/src/main/tut/docs/trees.md
@@ -13,3 +13,5 @@ The implementation of the Tree is encoded in [this file](https://github.com/scal
 The AST is organised in a series of traits and self-types, which follows the following structure: 
 
 WIP
+
+Want to contribute? [Edit this file](https://github.com/typelevel/scala/edit/typelevel-readme/src/main/resources/microsite/docs/trees.md)

--- a/src/main/tut/docs/trees.md
+++ b/src/main/tut/docs/trees.md
@@ -6,12 +6,8 @@ title: Trees
 This page describes the Scala [AST]() and its implementation within the Scala compiler code. 
 
 The AST is designed to capture the syntactic constructs of the Scala Programming Language, 
-as described in the [language specification](https://www.scala-lang.org/files/archive/spec/2.12/13-syntax-summary.html).
+as described in the [language specification](https://www.scala-lang.org/files/archive/spec/2.12/13-syntax-summary.html). The implementation of the Tree is encoded in [this file](https://github.com/scala/scala/blob/2.13.x/src/reflect/scala/reflect/internal/Trees.scala) 
 
-The implementation of the Tree is encoded in [this file](https://github.com/scala/scala/blob/2.13.x/src/reflect/scala/reflect/internal/Trees.scala) 
-
-The AST is organised in a series of traits and self-types, which follows the following structure: 
-
-WIP
+The official documentation of the compiler has a great section giving more details on  [Trees](http://docs.scala-lang.org/overviews/reflection/symbols-trees-types.html)/
 
 Want to contribute? [Edit this file](https://github.com/typelevel/scala/edit/typelevel-readme/src/main/resources/microsite/docs/trees.md)

--- a/src/main/tut/docs/types.md
+++ b/src/main/tut/docs/types.md
@@ -1,0 +1,8 @@
+---
+layout: docs
+title: Types
+---
+
+Types in scalac
+
+WIP

--- a/src/main/tut/docs/types.md
+++ b/src/main/tut/docs/types.md
@@ -6,3 +6,5 @@ title: Types
 Types in scalac
 
 WIP
+
+Want to contribute? [Edit this file](https://github.com/typelevel/scala/edit/typelevel-readme/src/main/resources/microsite/docs/types.md)


### PR DESCRIPTION
This is a follow up on https://github.com/typelevel/scala/pull/123 . It adds documentation on working with the compiler to the microsite.

Credit to @diesalbla and @rorygraves for a rework of the documentation contents. Any mistakes introduced are my fault :)

A note: the 'edit' links at the bottom of the pages have been added by hand as I wasn't sure how to translate the jekyll template to the microsite (it was getting convoluted). They should work, but needs to be improved in the future.

Let me know if you want some changes or feel free to edit files at will to follow any guidelines/rules I missed!

