### PR TITLE
Set micrositeDocumentationUrl as root-relative

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ micrositeHomepage := "http://typelevel.org/scala/"
 micrositeGithubOwner := "typelevel"
 micrositeGithubRepo := "scala"
 micrositeBaseUrl := "scala"
-micrositeDocumentationUrl := "docs/"
+micrositeDocumentationUrl := "/scala/docs"
 micrositeExtraMdFiles := Map(
   file("README.md") -> ExtraMdFileConfig(
     "index.md",


### PR DESCRIPTION
This change is due to to the documentation URL not being properly formed depending on the base href. By setting it as root-relative, we can be totally sure where we are pointing the link to.

Info related to this can be found on 47deg/sbt-microsites#251